### PR TITLE
docs: clarify distance usage in animation presets

### DIFF
--- a/src/animations/presets.ts
+++ b/src/animations/presets.ts
@@ -2,10 +2,11 @@ import { animationTokens } from './tokens';
 
 /**
  * Default animation presets. Each preset defines a keyframe name,
- * duration and easing function. Distances are specified as CSS
- * length values and should be interpreted relative to the current
- * layout. These presets correspond to the definitions in the
- * specification and can be passed to the Animations.play API.
+ * duration and easing function. A `distance` value may also be
+ * provided for translations; when present it is a CSS length
+ * interpreted relative to the current layout. These presets correspond
+ * to the definitions in the specification and can be passed to the
+ * Animations.play API.
  */
 export const presets = {
   dealCard: {


### PR DESCRIPTION
## Summary
- clarify that `distance` is optional and only used for translation animations

## Testing
- `npm test` *(fails: could not find a package.json file)*

------
https://chatgpt.com/codex/tasks/task_e_689d3ce6c638832f92acc394fa8cbe67