### PR TITLE
Add tests for game registry API

### DIFF
--- a/tests/gameAPI.test.ts
+++ b/tests/gameAPI.test.ts
@@ -1,0 +1,43 @@
+// @ts-ignore: node:test types are not available in this environment
+import { test } from 'node:test';
+// @ts-ignore: node:assert types are not available in this environment
+import assert from 'node:assert/strict';
+
+import { registerGame, getGame, GameRegistration } from '../src/gameAPI/index.js';
+
+test('registers and retrieves a game', () => {
+  const game: GameRegistration = {
+    slug: 'test-game',
+    meta: {},
+    createInitialState: () => ({}),
+    applyAction: (state) => state,
+    getPlayerView: (state) => state,
+    getNextActions: () => [],
+    rules: { validate: () => true },
+  };
+  registerGame(game);
+  assert.equal(getGame('test-game'), game);
+});
+
+test('registering same slug overwrites previous game', () => {
+  const first: GameRegistration = {
+    slug: 'shared-slug',
+    meta: { version: 1 },
+    createInitialState: () => ({}),
+    applyAction: (state) => state,
+    getPlayerView: (state) => state,
+    getNextActions: () => [],
+    rules: { validate: () => true },
+  };
+  const second: GameRegistration = {
+    ...first,
+    meta: { version: 2 },
+  };
+  registerGame(first);
+  registerGame(second);
+  assert.equal(getGame('shared-slug'), second);
+});
+
+test('getGame returns undefined for unknown slug', () => {
+  assert.equal(getGame('missing-slug'), undefined);
+});


### PR DESCRIPTION
## Summary
- add unit tests for game registration and lookup

## Testing
- `tsc tests/gameAPI.test.ts src/gameAPI/index.ts --outDir build --module ESNext --target ESNext --moduleResolution Node`
- `node --test build/tests/gameAPI.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689d3ceb1940832f9fb6264970240f6e