### PR TITLE
chore: add linting, testing and CI tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm typecheck
+      - run: pnpm lint
+      - run: pnpm test
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+playwright-report
+html-report
+.DS_Store

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# husky
+if [ -z "$husky_skip_init" ]; then
+  husky_skip_init=1
+  if [ -f "$HOME/.huskyrc" ]; then
+    . "$HOME/.huskyrc"
+  fi
+  export PATH="$PATH:/usr/local/bin"
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged
+pnpm lint && pnpm typecheck && pnpm test

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('basic check', async ({ page }) => {
+  // Simple assertion placeholder
+  expect(true).toBe(true);
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
+      eqeqeq: ['error', 'always']
+    }
+  },
+  prettier
+];

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  '*.{ts,tsx,js,json,md}': 'prettier --write',
+  'src/**/*.{ts,tsx}': 'eslint'
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "deck-arcade",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "e2e": "playwright test",
+    "prepare": "husky install"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.11.0",
+  "devDependencies": {
+    "@playwright/test": "^1.44.1",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitest/coverage-v8": "^1.4.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "husky": "^9.0.11",
+    "lint-staged": "^15.2.2",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.2",
+    "vitest": "^1.4.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    headless: true,
+    trace: 'retain-on-failure'
+  }
+});

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true
+};

--- a/tests/gameAPI.test.ts
+++ b/tests/gameAPI.test.ts
@@ -1,43 +1,41 @@
-// @ts-ignore: node:test types are not available in this environment
-import { test } from 'node:test';
-// @ts-ignore: node:assert types are not available in this environment
-import assert from 'node:assert/strict';
+import { describe, it, expect } from 'vitest';
+import { registerGame, getGame, type GameRegistration } from 'src/gameAPI';
 
-import { registerGame, getGame, GameRegistration } from '../src/gameAPI/index.js';
+describe('game registry', () => {
+  it('registers and retrieves a game', () => {
+    const game: GameRegistration = {
+      slug: 'test-game',
+      meta: {},
+      createInitialState: () => ({}),
+      applyAction: (state) => state,
+      getPlayerView: (state) => state,
+      getNextActions: () => [],
+      rules: { validate: () => true }
+    };
+    registerGame(game);
+    expect(getGame('test-game')).toBe(game);
+  });
 
-test('registers and retrieves a game', () => {
-  const game: GameRegistration = {
-    slug: 'test-game',
-    meta: {},
-    createInitialState: () => ({}),
-    applyAction: (state) => state,
-    getPlayerView: (state) => state,
-    getNextActions: () => [],
-    rules: { validate: () => true },
-  };
-  registerGame(game);
-  assert.equal(getGame('test-game'), game);
-});
+  it('registering same slug overwrites previous game', () => {
+    const first: GameRegistration = {
+      slug: 'shared-slug',
+      meta: { version: 1 },
+      createInitialState: () => ({}),
+      applyAction: (state) => state,
+      getPlayerView: (state) => state,
+      getNextActions: () => [],
+      rules: { validate: () => true }
+    };
+    const second: GameRegistration = {
+      ...first,
+      meta: { version: 2 }
+    };
+    registerGame(first);
+    registerGame(second);
+    expect(getGame('shared-slug')).toBe(second);
+  });
 
-test('registering same slug overwrites previous game', () => {
-  const first: GameRegistration = {
-    slug: 'shared-slug',
-    meta: { version: 1 },
-    createInitialState: () => ({}),
-    applyAction: (state) => state,
-    getPlayerView: (state) => state,
-    getNextActions: () => [],
-    rules: { validate: () => true },
-  };
-  const second: GameRegistration = {
-    ...first,
-    meta: { version: 2 },
-  };
-  registerGame(first);
-  registerGame(second);
-  assert.equal(getGame('shared-slug'), second);
-});
-
-test('getGame returns undefined for unknown slug', () => {
-  assert.equal(getGame('missing-slug'), undefined);
+  it('getGame returns undefined for unknown slug', () => {
+    expect(getGame('missing-slug')).toBeUndefined();
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "tests", "e2e"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      src: path.resolve(__dirname, './src')
+    }
+  },
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      statements: 90,
+      branches: 90,
+      functions: 90,
+      lines: 90
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- set up ESLint, Prettier, Vitest and Playwright configs
- add husky pre-commit with lint-staged
- run lint, typecheck, unit and e2e tests in CI

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@playwright%2Ftest: Forbidden - 403)*
- `pnpm typecheck` *(fails: Cannot find module '@playwright/test' or its corresponding type declarations)*
- `pnpm lint` *(fails: Cannot find package '@typescript-eslint/parser')*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d43c55a60832fb1336a88d0ce1192