### PR TITLE
refactor: remove button border radius cast

### DIFF
--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -24,7 +24,7 @@ const Button: React.FC<ButtonProps> = ({
 }) => {
   const baseStyles: React.CSSProperties = {
     padding: `${theme.spaceScale[3]} ${theme.spaceScale[5]}`,
-    borderRadius: theme.radius.md as unknown as number,
+    borderRadius: theme.radius.md,
     fontFamily: theme.typography.body,
     fontSize: '1rem',
     cursor: disabled ? 'not-allowed' : 'pointer',


### PR DESCRIPTION
## Summary
- remove unnecessary cast on button border radius so theme values apply as strings

## Testing
- `npm test` *(fails: Playwright Test did not expect test() to be called here)*
- `npx vitest run tests`
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-floating-promises')*
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_689d466d1fec832fbc0e0b6f71f24759