### PR TITLE
feat: implement money pool ledger and settlement

### DIFF
--- a/src/store/moneyPool.ts
+++ b/src/store/moneyPool.ts
@@ -1,13 +1,141 @@
 /**
- * State representation for a shared chip pool. This is a simple data
- * structure that tracks the number of chips available to a player.
- * Advanced functionality like buy‑ins, rakes and loans will be added
- * later in the development process.
+ * Money pool with ledger and balance tracking.
+ * Supports buy-ins, betting and settlement with optional rake.
  */
-export interface MoneyPool {
-  chips: number;
+
+export interface LedgerEntry {
+  handId: string;
+  playerId: string;
+  delta: number;
+  reason: string;
+  ts: number;
 }
 
-export function createInitialMoneyPool(initialChips: number = 1000): MoneyPool {
-  return { chips: initialChips };
+export interface SettlementOutcome {
+  playerId: string;
+  /** amount originally bet */
+  amount: number;
+  result: 'win' | 'lose' | 'push';
+  reason?: string;
 }
+
+export interface MoneyPool {
+  ledger: LedgerEntry[];
+  balances: Record<string, number>;
+  rake: number;
+  loansAllowed: boolean;
+  buyIn(playerId: string, amount: number): void;
+  canBet(playerId: string, amount: number): boolean;
+  recordBet(handId: string, playerId: string, amount: number): void;
+  settle(
+    handId: string,
+    outcomes: SettlementOutcome[],
+    options?: { rake?: { percent: number } },
+  ): { rake: number };
+  carryAcrossGames(playerId: string): { balance: number; lastUpdate: number };
+  exportCsv(): string;
+}
+
+export function createMoneyPool(
+  options: { loansAllowed?: boolean } = {},
+): MoneyPool {
+  const pool: MoneyPool = {
+    ledger: [],
+    balances: {},
+    rake: 0,
+    loansAllowed: options.loansAllowed ?? false,
+    buyIn(playerId: string, amount: number) {
+      const ts = Date.now();
+      pool.ledger.push({
+        handId: 'buyIn',
+        playerId,
+        delta: amount,
+        reason: 'buyIn',
+        ts,
+      });
+      pool.balances[playerId] = (pool.balances[playerId] ?? 0) + amount;
+    },
+    canBet(playerId: string, amount: number) {
+      if (pool.loansAllowed) return true;
+      return (pool.balances[playerId] ?? 0) >= amount;
+    },
+    recordBet(handId: string, playerId: string, amount: number) {
+      if (!pool.canBet(playerId, amount)) {
+        throw new Error('insufficient balance');
+      }
+      const ts = Date.now();
+      pool.ledger.push({
+        handId,
+        playerId,
+        delta: -amount,
+        reason: 'bet',
+        ts,
+      });
+      pool.balances[playerId] = (pool.balances[playerId] ?? 0) - amount;
+    },
+    settle(
+      handId: string,
+      outcomes: SettlementOutcome[],
+      options?: { rake?: { percent: number } },
+    ) {
+      const ts = Date.now();
+      const rakePercent = options?.rake?.percent ?? 0;
+      let totalRake = 0;
+      for (const outcome of outcomes) {
+        let payout = 0;
+        if (outcome.result === 'win') payout = outcome.amount * 2;
+        else if (outcome.result === 'push') payout = outcome.amount;
+        if (payout > 0) {
+          const rakeAmount = (payout * rakePercent) / 100;
+          if (rakeAmount > 0) {
+            payout -= rakeAmount;
+            totalRake += rakeAmount;
+          }
+          pool.ledger.push({
+            handId,
+            playerId: outcome.playerId,
+            delta: payout,
+            reason: outcome.reason ?? 'settle',
+            ts,
+          });
+          pool.balances[outcome.playerId] =
+            (pool.balances[outcome.playerId] ?? 0) + payout;
+        }
+      }
+      pool.rake += totalRake;
+      if (!pool.loansAllowed) {
+        for (const id of Object.keys(pool.balances)) {
+          if (pool.balances[id] < 0) {
+            throw new Error('negative balance');
+          }
+        }
+      }
+      return { rake: totalRake };
+    },
+    carryAcrossGames(playerId: string) {
+      const balance = pool.balances[playerId] ?? 0;
+      let lastUpdate = 0;
+      for (let i = pool.ledger.length - 1; i >= 0; i--) {
+        const entry = pool.ledger[i];
+        if (entry.playerId === playerId) {
+          lastUpdate = entry.ts;
+          break;
+        }
+      }
+      return { balance, lastUpdate };
+    },
+    exportCsv() {
+      const header = 'handId,playerId,delta,reason,ts';
+      const rows = pool.ledger.map(
+        (e) => `${e.handId},${e.playerId},${e.delta},${e.reason},${e.ts}`,
+      );
+      return [header, ...rows].join('\n');
+    },
+  };
+  return pool;
+}
+
+/**
+ * @deprecated use createMoneyPool instead
+ */
+export const createInitialMoneyPool = createMoneyPool;

--- a/tests/gameAPI.test.ts
+++ b/tests/gameAPI.test.ts
@@ -7,10 +7,10 @@ describe('game registry', () => {
       slug: 'test-game',
       meta: {},
       createInitialState: () => ({}),
-      applyAction: (state) => state,
-      getPlayerView: (state) => state,
+      applyAction: (state: unknown) => state,
+      getPlayerView: (state: unknown) => state,
       getNextActions: () => [],
-      rules: { validate: () => true }
+      rules: { validate: () => true },
     };
     registerGame(game);
     expect(getGame('test-game')).toBe(game);
@@ -21,14 +21,14 @@ describe('game registry', () => {
       slug: 'shared-slug',
       meta: { version: 1 },
       createInitialState: () => ({}),
-      applyAction: (state) => state,
-      getPlayerView: (state) => state,
+      applyAction: (state: unknown) => state,
+      getPlayerView: (state: unknown) => state,
       getNextActions: () => [],
-      rules: { validate: () => true }
+      rules: { validate: () => true },
     };
     const second: GameRegistration = {
       ...first,
-      meta: { version: 2 }
+      meta: { version: 2 },
     };
     registerGame(first);
     registerGame(second);

--- a/tests/moneyPool.test.ts
+++ b/tests/moneyPool.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { createMoneyPool } from 'src/store/moneyPool';
+
+describe('money pool ledger', () => {
+  it('rebuilds balances deterministically from ledger', () => {
+    const pool = createMoneyPool();
+    pool.buyIn('p1', 100);
+    pool.buyIn('p2', 100);
+    pool.recordBet('h1', 'p1', 50);
+    pool.recordBet('h1', 'p2', 50);
+    pool.settle('h1', [
+      { playerId: 'p1', result: 'win', amount: 50 },
+      { playerId: 'p2', result: 'lose', amount: 50 },
+    ]);
+
+    const rebuilt: Record<string, number> = {};
+    for (const entry of pool.ledger) {
+      rebuilt[entry.playerId] = (rebuilt[entry.playerId] ?? 0) + entry.delta;
+    }
+    expect(rebuilt).toEqual(pool.balances);
+  });
+
+  it('conserves chips on settlement including rake', () => {
+    const pool = createMoneyPool();
+    pool.buyIn('p1', 100);
+    pool.buyIn('p2', 100);
+    pool.recordBet('h2', 'p1', 50);
+    pool.recordBet('h2', 'p2', 50);
+    pool.settle(
+      'h2',
+      [
+        { playerId: 'p1', result: 'win', amount: 50 },
+        { playerId: 'p2', result: 'lose', amount: 50 },
+      ],
+      { rake: { percent: 10 } },
+    );
+
+    const handSum = pool.ledger
+      .filter((e: any) => e.handId === 'h2')
+      .reduce((acc: number, e: any) => acc + e.delta, 0);
+    expect(handSum + pool.rake).toBe(0);
+  });
+
+  it('disallows negative balances unless loans are allowed', () => {
+    const pool = createMoneyPool();
+    pool.buyIn('p1', 50);
+    expect(() => pool.recordBet('h3', 'p1', 60)).toThrow();
+
+    const loanPool = createMoneyPool({ loansAllowed: true });
+    expect(() => loanPool.recordBet('h3', 'p1', 60)).not.toThrow();
+    expect(loanPool.balances['p1']).toBe(-60);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
   },
   "include": ["src", "tests", "e2e"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,20 +1,21 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
   resolve: {
     alias: {
-      src: path.resolve(__dirname, './src')
-    }
+      src: path.resolve(__dirname, './src'),
+    },
   },
   test: {
+    exclude: [...configDefaults.exclude, 'e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       statements: 90,
       branches: 90,
       functions: 90,
-      lines: 90
-    }
-  }
+      lines: 90,
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- implement chip ledger with buy-ins, bets, settlement and rake
- expose helpers for carrying balances and CSV export
- cover replay determinism, conservation and loan rules in tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d49f2c848832f8f19f0b47a51352d