### PR TITLE
feat: add blackjack singleplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zod": "^4.0.17"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: ^4.0.17
+        version: 4.0.17
     devDependencies:
       '@playwright/test':
         specifier: ^1.44.1
@@ -1355,6 +1358,9 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  zod@4.0.17:
+    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -2591,3 +2597,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  zod@4.0.17: {}

--- a/src/games/blackjack/index.ts
+++ b/src/games/blackjack/index.ts
@@ -1,53 +1,6 @@
-import { registerGame, GameRegistration } from '../../gameAPI';
+import BlackjackUI from './ui';
+import { registerGame } from './rules';
 
-/**
- * Basic skeleton for the blackjack game. The actual logic for
- * blackjack will be implemented in steps according to the product
- * specification. For now we register a simple object so that the
- * game appears in the registry.
- */
-const blackjackGame: GameRegistration = {
-  slug: 'blackjack',
-  meta: {
-    title: 'Blackjack',
-    players: '1–7'
-  },
-  createInitialState(seed: number) {
-    // TODO: generate a shuffled shoe and initial table state based on seed
-    return { seed };
-  },
-  applyAction(state: unknown, action: unknown) {
-    // TODO: update state according to blackjack rules
-    return state;
-  },
-  getPlayerView(state: unknown, playerId: string) {
-    // TODO: return the portion of state visible to the specified player
-    return state;
-  },
-  getNextActions(state: unknown, playerId: string) {
-    // TODO: compute the list of allowed actions
-    return [];
-  },
-  rules: {
-    validate(state: unknown, action: unknown) {
-      // TODO: enforce blackjack move legality
-      return true;
-    }
-  },
-  explainers: {
-    getTips(state: unknown, playerId: string) {
-      // TODO: return contextual hints such as when to hit or stand
-      return [];
-    }
-  },
-  animations: {},
-  payouts: {
-    settle(economyState: unknown, tableState: unknown) {
-      // TODO: move chips based on results of the hand
-      return {};
-    }
-  }
-};
+registerGame();
 
-// Register the game so that it can be discovered by the UI.
-registerGame(blackjackGame);
+export default BlackjackUI;

--- a/src/games/blackjack/rules.ts
+++ b/src/games/blackjack/rules.ts
@@ -1,18 +1,420 @@
-/**
- * Detailed blackjack rule definitions. This file will ultimately
- * contain functions to evaluate hands, determine winning conditions
- * and compute payouts. For now it exports stubs to allow module
- * references without throwing errors.
- */
+import { z } from 'zod';
+import { registerGame as register } from '../../gameAPI';
 
-export type BlackjackAction = 'hit' | 'stand' | 'double' | 'split' | 'surrender';
-
-export function isActionValid(/* state: unknown, action: BlackjackAction */): boolean {
-  // TODO: enforce blackjack rules such as limits on splitting and surrender
-  return true;
+export type Rank =
+  | 'A'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | 'J'
+  | 'Q'
+  | 'K';
+export type Suit = 'S' | 'H' | 'D' | 'C';
+export interface Card {
+  rank: Rank;
+  suit: Suit;
 }
 
-export function getHandValue(/* hand: Card[] */): number {
-  // TODO: compute the numeric value of a blackjack hand
-  return 0;
+export type BlackjackAction =
+  | 'hit'
+  | 'stand'
+  | 'double'
+  | 'split'
+  | 'surrender';
+
+export const configSchema = z.object({
+  h17: z.boolean(),
+  das: z.boolean(),
+  resplitAces: z.boolean(),
+  surrender: z.enum(['none', 'late', 'early']),
+  payout: z.enum(['3:2', '6:5']),
+  penetration: z.number().min(0).max(1),
+  minBet: z.number().optional(),
+  maxBet: z.number().optional(),
+});
+
+export type BlackjackConfig = z.infer<typeof configSchema>;
+
+export interface Hand {
+  cards: Card[];
+  bet: number;
+  splitAces?: boolean;
+  fromSplit?: boolean;
+  hasActed?: boolean;
+  result?: Outcome['result'];
+}
+
+export interface Outcome {
+  result: 'win' | 'lose' | 'push' | 'blackjack' | 'surrender';
+  bet: number;
+}
+
+export interface GameState {
+  shoe: Card[];
+  discard: Card[];
+  dealer: Card[];
+  hands: Hand[];
+  active: number;
+  config: BlackjackConfig;
+  stage: 'player' | 'dealer' | 'finished';
+  bank: number;
+  events: { type: string }[];
+  shoeSize: number; // original size for penetration tracking
+}
+
+function createDeck(): Card[] {
+  const ranks: Rank[] = [
+    'A',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '10',
+    'J',
+    'Q',
+    'K',
+  ];
+  const suits: Suit[] = ['S', 'H', 'D', 'C'];
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (const rank of ranks) {
+      deck.push({ rank, suit });
+    }
+  }
+  return deck;
+}
+
+function shuffle(cards: Card[]): Card[] {
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cards[i], cards[j]] = [cards[j], cards[i]];
+  }
+  return cards;
+}
+
+function cardValue(card: Card): number {
+  switch (card.rank) {
+    case 'A':
+      return 11;
+    case 'K':
+    case 'Q':
+    case 'J':
+    case '10':
+      return 10;
+    default:
+      return parseInt(card.rank, 10);
+  }
+}
+
+export function getHandValue(hand: Card[]): { total: number; soft: boolean } {
+  let total = 0;
+  let aces = 0;
+  for (const c of hand) {
+    if (c.rank === 'A') aces++;
+    total += cardValue(c);
+  }
+  while (total > 21 && aces > 0) {
+    total -= 10;
+    aces--;
+  }
+  return { total, soft: aces > 0 };
+}
+
+export function isBlackjack(hand: Card[]): boolean {
+  return hand.length === 2 && getHandValue(hand).total === 21;
+}
+
+function dealCard(state: GameState, target: Card[]): void {
+  const card = state.shoe.pop();
+  if (card) target.push(card);
+  checkPenetration(state);
+}
+
+function checkPenetration(state: GameState): void {
+  const used = state.shoeSize - state.shoe.length;
+  if (used / state.shoeSize >= state.config.penetration) {
+    state.events.push({ type: 'reshuffle' });
+    state.shoe = shuffle(createDeck());
+    state.discard = [];
+    state.shoeSize = state.shoe.length;
+  }
+}
+
+export function createInitialState(config: BlackjackConfig): GameState {
+  const shoe = shuffle(createDeck());
+  const state: GameState = {
+    shoe,
+    discard: [],
+    dealer: [],
+    hands: [{ cards: [], bet: config.minBet ?? 10 }],
+    active: 0,
+    config,
+    stage: 'player',
+    bank: 100,
+    events: [],
+    shoeSize: shoe.length,
+  };
+
+  // Initial deal
+  dealCard(state, state.hands[0].cards);
+  dealCard(state, state.dealer);
+  dealCard(state, state.hands[0].cards);
+  dealCard(state, state.dealer);
+
+  if (config.surrender !== 'early') {
+    const dealerBJ = isBlackjack(state.dealer);
+    const playerBJ = isBlackjack(state.hands[0].cards);
+    if (dealerBJ || playerBJ) {
+      const outcome: Outcome = dealerBJ
+        ? playerBJ
+          ? { result: 'push', bet: state.hands[0].bet }
+          : { result: 'lose', bet: state.hands[0].bet }
+        : { result: 'blackjack', bet: state.hands[0].bet };
+      state.bank += payouts.settle([outcome], config);
+      state.hands[0].result = outcome.result;
+      state.stage = 'finished';
+    }
+  }
+  return state;
+}
+
+function moveToNextHand(state: GameState): void {
+  state.active++;
+  if (state.active >= state.hands.length) {
+    dealerPlay(state);
+  }
+}
+
+function dealerPlay(state: GameState): void {
+  state.stage = 'dealer';
+  while (true) {
+    const value = getHandValue(state.dealer);
+    if (
+      value.total < 17 ||
+      (value.total === 17 && value.soft && state.config.h17)
+    ) {
+      dealCard(state, state.dealer);
+    } else {
+      break;
+    }
+  }
+
+  const dealerValue = getHandValue(state.dealer).total;
+  const dealerBust = dealerValue > 21;
+  const outcomes: Outcome[] = [];
+
+  for (const hand of state.hands) {
+    if (hand.result) {
+      outcomes.push({ result: hand.result, bet: hand.bet });
+      continue;
+    }
+    const playerValue = getHandValue(hand.cards).total;
+    if (playerValue > 21) {
+      outcomes.push({ result: 'lose', bet: hand.bet });
+    } else if (dealerBust) {
+      outcomes.push({ result: 'win', bet: hand.bet });
+    } else if (isBlackjack(hand.cards) && !isBlackjack(state.dealer)) {
+      outcomes.push({ result: 'blackjack', bet: hand.bet });
+    } else if (playerValue > dealerValue) {
+      outcomes.push({ result: 'win', bet: hand.bet });
+    } else if (playerValue < dealerValue) {
+      outcomes.push({ result: 'lose', bet: hand.bet });
+    } else {
+      outcomes.push({ result: 'push', bet: hand.bet });
+    }
+  }
+
+  state.bank += payouts.settle(outcomes, state.config);
+  state.stage = 'finished';
+}
+
+export function applyAction(
+  state: GameState,
+  action: BlackjackAction,
+): GameState {
+  if (state.stage !== 'player') return state;
+  const hand = state.hands[state.active];
+
+  switch (action) {
+    case 'hit':
+      dealCard(state, hand.cards);
+      hand.hasActed = true;
+      if (getHandValue(hand.cards).total > 21) {
+        hand.result = 'lose';
+        state.bank += payouts.settle(
+          [{ result: 'lose', bet: hand.bet }],
+          state.config,
+        );
+        moveToNextHand(state);
+      }
+      break;
+    case 'stand':
+      hand.hasActed = true;
+      moveToNextHand(state);
+      break;
+    case 'double':
+      if (state.bank >= hand.bet) {
+        state.bank -= hand.bet;
+        hand.bet *= 2;
+        dealCard(state, hand.cards);
+        hand.hasActed = true;
+        if (getHandValue(hand.cards).total > 21) {
+          hand.result = 'lose';
+          state.bank += payouts.settle(
+            [{ result: 'lose', bet: hand.bet }],
+            state.config,
+          );
+        }
+        moveToNextHand(state);
+      }
+      break;
+    case 'split':
+      if (
+        hand.cards.length === 2 &&
+        hand.cards[0].rank === hand.cards[1].rank
+      ) {
+        if (state.bank >= hand.bet) {
+          state.bank -= hand.bet;
+          const [c1, c2] = hand.cards;
+          const newHand1: Hand = {
+            cards: [c1],
+            bet: hand.bet,
+            splitAces: c1.rank === 'A',
+            fromSplit: true,
+          };
+          const newHand2: Hand = {
+            cards: [c2],
+            bet: hand.bet,
+            splitAces: c2.rank === 'A',
+            fromSplit: true,
+          };
+          state.hands[state.active] = newHand1;
+          state.hands.splice(state.active + 1, 0, newHand2);
+          dealCard(state, newHand1.cards);
+          dealCard(state, newHand2.cards);
+        }
+      }
+      break;
+    case 'surrender':
+      hand.result = 'surrender';
+      state.bank += payouts.settle(
+        [{ result: 'surrender', bet: hand.bet }],
+        state.config,
+      );
+      state.stage = 'finished';
+      break;
+  }
+
+  return state;
+}
+
+export function getPlayerView(state: GameState, _playerId: string): GameState {
+  return state;
+}
+
+export function getNextActions(
+  state: GameState,
+  _playerId: string,
+): BlackjackAction[] {
+  if (state.stage !== 'player') return [];
+  const hand = state.hands[state.active];
+  const actions: BlackjackAction[] = ['hit', 'stand'];
+
+  if (hand.cards.length === 2 && state.bank >= hand.bet) {
+    if (!hand.splitAces || state.config.resplitAces) {
+      if (hand.cards[0].rank === hand.cards[1].rank) {
+        actions.push('split');
+      }
+    }
+    if (!hand.hasActed) {
+      if (!hand.fromSplit || state.config.das) actions.push('double');
+      if (state.config.surrender === 'early') {
+        actions.push('surrender');
+      } else if (
+        state.config.surrender === 'late' &&
+        !isBlackjack(state.dealer)
+      ) {
+        actions.push('surrender');
+      }
+    }
+  }
+  return actions;
+}
+
+export const rules = {
+  validate(_state: GameState, action: unknown): boolean {
+    const schema = z.object({
+      action: z.enum(['hit', 'stand', 'double', 'split', 'surrender']),
+    });
+    return schema.safeParse({ action }).success;
+  },
+};
+
+export const payouts = {
+  settle(outcomes: Outcome[], config: BlackjackConfig): number {
+    let delta = 0;
+    for (const o of outcomes) {
+      switch (o.result) {
+        case 'win':
+          delta += o.bet;
+          break;
+        case 'lose':
+          delta -= o.bet;
+          break;
+        case 'push':
+          break;
+        case 'blackjack':
+          delta += o.bet * (config.payout === '3:2' ? 1.5 : 1.2);
+          break;
+        case 'surrender':
+          delta -= o.bet / 2;
+          break;
+      }
+    }
+    return delta;
+  },
+};
+
+export function registerGame(): void {
+  const defaultConfig: BlackjackConfig = {
+    h17: false,
+    das: false,
+    resplitAces: false,
+    surrender: 'none',
+    payout: '3:2',
+    penetration: 1,
+  };
+  register({
+    slug: 'blackjack',
+    meta: { title: 'Blackjack', players: '1' },
+    createInitialState: (() => createInitialState(defaultConfig)) as any,
+    applyAction: ((state: unknown, action: unknown) =>
+      applyAction(state as GameState, action as BlackjackAction)) as any,
+    getPlayerView: ((state: unknown, player: string) =>
+      getPlayerView(state as GameState, player)) as any,
+    getNextActions: ((state: unknown, player: string) =>
+      getNextActions(state as GameState, player)) as any,
+    rules: {
+      validate: (state: unknown, action: unknown) =>
+        rules.validate(state as GameState, action),
+    },
+    payouts: {
+      settle: (outcomes: unknown, config: unknown) =>
+        payouts.settle(outcomes as Outcome[], config as BlackjackConfig),
+    },
+  });
+}
+
+export function cardToString(card: Card): string {
+  return card.rank + card.suit;
 }

--- a/src/games/blackjack/ui.tsx
+++ b/src/games/blackjack/ui.tsx
@@ -1,23 +1,59 @@
-import React from 'react';
+import React, { useReducer } from 'react';
+import {
+  BlackjackAction,
+  BlackjackConfig,
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions,
+  cardToString,
+} from './rules';
 
-/**
- * UI component for the blackjack table. At this stage of
- * development it renders a placeholder. Subsequent iterations will
- * include bet placement, dealing animations and interactive player
- * controls.
- */
+const defaultConfig: BlackjackConfig = {
+  h17: false,
+  das: true,
+  resplitAces: false,
+  surrender: 'late',
+  payout: '3:2',
+  penetration: 0.75,
+};
+
+function reducer(state: any, action: BlackjackAction) {
+  return { ...applyAction(state, action) };
+}
+
 const BlackjackUI: React.FC = () => {
+  const [state, dispatch] = useReducer(
+    reducer,
+    createInitialState(defaultConfig),
+  );
+  const view = getPlayerView(state, 'player');
+  const actions = getNextActions(state, 'player');
+  const hand = view.hands[view.active]?.cards ?? [];
+
   return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        color: '#fff'
-      }}
-    >
-      Blackjack table coming soon
+    <div style={{ color: '#fff' }}>
+      <div>Dealer: {view.dealer.map(cardToString).join(' ')}</div>
+      <div>Player: {hand.map(cardToString).join(' ')}</div>
+      <div>
+        Bank: {view.bank} Bet: {view.hands[view.active]?.bet ?? 0}
+      </div>
+      <div>
+        {actions.map((a) => (
+          <button
+            key={a}
+            onClick={() => dispatch(a)}
+            style={{ marginRight: 8 }}
+          >
+            {a}
+          </button>
+        ))}
+      </div>
+      <ul>
+        {view.events.map((e: any, i: number) => (
+          <li key={i}>{e.type}</li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/tests/blackjack.test.ts
+++ b/tests/blackjack.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BlackjackConfig,
+  createInitialState,
+  applyAction,
+  getNextActions,
+  payouts,
+  type GameState,
+  type Card,
+} from 'src/games/blackjack/rules';
+
+const card = (rank: Card['rank']): Card => ({ rank, suit: 'S' });
+
+const baseConfig: BlackjackConfig = {
+  h17: false,
+  das: false,
+  resplitAces: false,
+  surrender: 'none',
+  payout: '3:2',
+  penetration: 1,
+};
+
+describe('dealer stopping', () => {
+  it('hits soft 17 when h17 is true', () => {
+    const state = createInitialState({ ...baseConfig, h17: true });
+    state.dealer = [card('A'), card('6')];
+    state.hands = [{ cards: [card('10'), card('7')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('2')];
+    state.shoeSize = 1;
+    applyAction(state, 'stand');
+    expect(state.dealer.length).toBe(3);
+  });
+
+  it('stands on soft 17 when h17 is false', () => {
+    const state = createInitialState({ ...baseConfig, h17: false });
+    state.dealer = [card('A'), card('6')];
+    state.hands = [{ cards: [card('10'), card('7')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('2')];
+    state.shoeSize = 1;
+    applyAction(state, 'stand');
+    expect(state.dealer.length).toBe(2);
+  });
+});
+
+describe('double after split', () => {
+  it('allows double after split when das is true', () => {
+    const config = { ...baseConfig, das: true };
+    const state = createInitialState(config);
+    state.hands = [{ cards: [card('8'), card('8')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('5'), card('5')];
+    state.shoeSize = 2;
+    applyAction(state, 'split');
+    const actions = getNextActions(state, 'player');
+    expect(actions).toContain('double');
+  });
+
+  it('forbids double after split when das is false', () => {
+    const config = { ...baseConfig, das: false };
+    const state = createInitialState(config);
+    state.hands = [{ cards: [card('8'), card('8')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('5'), card('5')];
+    state.shoeSize = 2;
+    applyAction(state, 'split');
+    const actions = getNextActions(state, 'player');
+    expect(actions).not.toContain('double');
+  });
+});
+
+describe('resplit aces', () => {
+  it('allows resplitting aces when enabled', () => {
+    const config = { ...baseConfig, resplitAces: true };
+    const state = createInitialState(config);
+    state.hands = [{ cards: [card('A'), card('A')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('9'), card('A')];
+    state.shoeSize = 2;
+    applyAction(state, 'split');
+    const actions = getNextActions(state, 'player');
+    expect(actions).toContain('split');
+  });
+
+  it('disallows resplitting aces when disabled', () => {
+    const config = { ...baseConfig, resplitAces: false };
+    const state = createInitialState(config);
+    state.hands = [{ cards: [card('A'), card('A')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('9'), card('A')];
+    state.shoeSize = 2;
+    applyAction(state, 'split');
+    const actions = getNextActions(state, 'player');
+    expect(actions).not.toContain('split');
+  });
+});
+
+describe('surrender semantics', () => {
+  it('allows early surrender even against dealer blackjack', () => {
+    const config: BlackjackConfig = { ...baseConfig, surrender: 'early' };
+    const state = createInitialState(config);
+    state.dealer = [card('A'), card('10')];
+    state.hands = [{ cards: [card('9'), card('7')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    applyAction(state, 'surrender');
+    expect(state.bank).toBe(95);
+    expect(state.stage).toBe('finished');
+  });
+
+  it('forbids surrender when dealer has blackjack and surrender is late', () => {
+    const config: BlackjackConfig = { ...baseConfig, surrender: 'late' };
+    const state = createInitialState(config);
+    state.dealer = [card('A'), card('10')];
+    state.hands = [{ cards: [card('9'), card('7')], bet: 10 }];
+    state.stage = 'player';
+    const actions = getNextActions(state, 'player');
+    expect(actions).not.toContain('surrender');
+  });
+
+  it('forbids surrender when option is none', () => {
+    const config: BlackjackConfig = { ...baseConfig, surrender: 'none' };
+    const state = createInitialState(config);
+    state.dealer = [card('9'), card('7')];
+    state.hands = [{ cards: [card('9'), card('7')], bet: 10 }];
+    state.stage = 'player';
+    const actions = getNextActions(state, 'player');
+    expect(actions).not.toContain('surrender');
+  });
+});
+
+describe('payouts', () => {
+  it('pays 3:2 or 6:5 for blackjack and 0 for pushes', () => {
+    expect(
+      payouts.settle([{ result: 'blackjack', bet: 10 }], {
+        ...baseConfig,
+        payout: '3:2',
+      }),
+    ).toBe(15);
+    expect(
+      payouts.settle([{ result: 'blackjack', bet: 10 }], {
+        ...baseConfig,
+        payout: '6:5',
+      }),
+    ).toBe(12);
+    expect(payouts.settle([{ result: 'push', bet: 10 }], baseConfig)).toBe(0);
+  });
+});
+
+describe('penetration reshuffle', () => {
+  it('emits reshuffle when penetration threshold reached', () => {
+    const config = { ...baseConfig, penetration: 0.5 };
+    const state: GameState = {
+      shoe: [card('3'), card('2'), card('4')],
+      discard: [],
+      dealer: [card('9'), card('7')],
+      hands: [{ cards: [card('5'), card('5')], bet: 10 }],
+      active: 0,
+      config,
+      stage: 'player',
+      bank: 100,
+      events: [],
+      shoeSize: 3,
+    };
+    applyAction(state, 'hit');
+    expect(state.events.length).toBe(0);
+    applyAction(state, 'hit');
+    expect(state.events.find((e) => e.type === 'reshuffle')).toBeTruthy();
+  });
+});
+
+describe('auto resolve', () => {
+  it('resolves automatically on stand', () => {
+    const state = createInitialState(baseConfig);
+    state.dealer = [card('10'), card('7')];
+    state.hands = [{ cards: [card('9'), card('8')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [];
+    state.shoeSize = 0;
+    applyAction(state, 'stand');
+    expect(state.stage).toBe('finished');
+  });
+
+  it('resolves automatically on bust', () => {
+    const state = createInitialState(baseConfig);
+    state.dealer = [card('10'), card('7')];
+    state.hands = [{ cards: [card('9'), card('8')], bet: 10 }];
+    state.stage = 'player';
+    state.active = 0;
+    state.shoe = [card('5')];
+    state.shoeSize = 1;
+    applyAction(state, 'hit');
+    expect(state.stage).toBe('finished');
+  });
+});


### PR DESCRIPTION
## Summary
- implement blackjack rules with configurable options and payouts
- render minimal single-player blackjack table
- test blackjack edge cases and payouts

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4cc1b834832fa1d2e7344d6015dc