### PR TITLE
feat: add voice push-to-talk

### DIFF
--- a/e2e/voice-ptt.spec.ts
+++ b/e2e/voice-ptt.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+test('send and receive audio via push-to-talk', async ({ page, context }) => {
+  await context.grantPermissions(['microphone'], {
+    origin: 'http://localhost:5173',
+  });
+  const page2 = await context.newPage();
+  await Promise.all([page.goto('/'), page2.goto('/')]);
+
+  await page2.evaluate(() => {
+    const pc = new RTCPeerConnection();
+    (window as any).pc = pc;
+    (window as any).received = false;
+    pc.ontrack = () => {
+      (window as any).received = true;
+    };
+  });
+
+  await page.evaluate(async () => {
+    const pc = new RTCPeerConnection();
+    (window as any).pc = pc;
+    const path = '/src/comms/VoicePTT.ts';
+    const mod = await import(path);
+    mod.initVoicePTT(pc);
+  });
+
+  const offer = await page.evaluate(async () => {
+    const pc: RTCPeerConnection = (window as any).pc;
+    const offer = await pc.createOffer();
+    await pc.setLocalDescription(offer);
+    await new Promise((r) => {
+      if (pc.iceGatheringState === 'complete') {
+        r(null);
+      } else {
+        pc.addEventListener('icegatheringstatechange', () => {
+          if (pc.iceGatheringState === 'complete') r(null);
+        });
+      }
+    });
+    return pc.localDescription?.sdp;
+  });
+
+  const answer = await page2.evaluate(async (offerSdp) => {
+    const pc: RTCPeerConnection = (window as any).pc;
+    await pc.setRemoteDescription({ type: 'offer', sdp: offerSdp });
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+    await new Promise((r) => {
+      if (pc.iceGatheringState === 'complete') {
+        r(null);
+      } else {
+        pc.addEventListener('icegatheringstatechange', () => {
+          if (pc.iceGatheringState === 'complete') r(null);
+        });
+      }
+    });
+    return pc.localDescription?.sdp;
+  }, offer);
+
+  await page.evaluate(async (answerSdp) => {
+    const pc: RTCPeerConnection = (window as any).pc;
+    await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
+  }, answer);
+
+  await page.keyboard.down(' ');
+  await expect
+    .poll(async () => {
+      return await page2.evaluate(() => (window as any).received);
+    })
+    .toBe(true);
+  await page.keyboard.up(' ');
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
     headless: true,
     baseURL: 'http://localhost:5173',
     trace: 'retain-on-failure',
+    launchOptions: {
+      args: ['--use-fake-device-for-media-stream'],
+    },
   },
   webServer: {
     command: 'pnpm exec vite dev --port 5173',

--- a/src/comms/VoicePTT.ts
+++ b/src/comms/VoicePTT.ts
@@ -1,12 +1,140 @@
 /**
- * Placeholder for voice chat implementation. Push‑to‑talk functionality
- * will be handled by the networking layer; for now this file simply
- * exports stubs that can be called by future UI components.
+ * Push-to-talk voice chat implementation using WebRTC.
+ * Captures microphone input with noise filtering and toggles
+ * the audio track on key press (Space) or when voice activity
+ * is detected as a fallback. Server moderation can mute the
+ * local user which removes the track and prevents further
+ * sending until unmuted.
  */
-export function startPushToTalk() {
-  // TODO: start capturing microphone audio on key press
+let pc: RTCPeerConnection | null = null;
+let sender: RTCRtpSender | null = null;
+let stream: MediaStream | null = null;
+let pressed = false;
+let speaking = false;
+let muted = false;
+let indicator: HTMLElement | null = null;
+let analyser: AnalyserNode | null = null;
+let dataArray: Float32Array = new Float32Array(0);
+let rafId: number | null = null;
+
+export function initVoicePTT(
+  connection: RTCPeerConnection,
+  indicatorEl?: HTMLElement,
+) {
+  pc = connection;
+  indicator = indicatorEl ?? document.getElementById('pttIndicator');
+  window.addEventListener('keydown', onKeyDown);
+  window.addEventListener('keyup', onKeyUp);
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.code === 'Space') {
+    e.preventDefault();
+    void startPushToTalk();
+  }
+}
+
+function onKeyUp(e: KeyboardEvent) {
+  if (e.code === 'Space') {
+    e.preventDefault();
+    stopPushToTalk();
+  }
+}
+
+async function ensureStream() {
+  if (!stream) {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+    setupVAD();
+  }
+}
+
+function enableTrack() {
+  if (!stream || !pc || muted) return;
+  const track = stream.getAudioTracks()[0];
+  if (sender) {
+    void sender.replaceTrack(track);
+  } else {
+    sender = pc.addTrack(track, stream);
+  }
+  indicator?.classList.add('speaking');
+}
+
+function disableTrack() {
+  if (sender) void sender.replaceTrack(null);
+  indicator?.classList.remove('speaking');
+}
+
+export async function startPushToTalk() {
+  if (muted) return;
+  pressed = true;
+  await ensureStream();
+  enableTrack();
 }
 
 export function stopPushToTalk() {
-  // TODO: stop capturing microphone audio
+  pressed = false;
+  if (!speaking || muted) {
+    disableTrack();
+  }
+  indicator?.classList.toggle('speaking', pressed || speaking);
+}
+
+export function setMuted(value: boolean) {
+  muted = value;
+  if (muted) {
+    disableTrack();
+  }
+}
+
+function setupVAD() {
+  if (!stream || typeof AudioContext === 'undefined') return;
+  const ctx = new AudioContext();
+  const source = ctx.createMediaStreamSource(stream);
+  analyser = ctx.createAnalyser();
+  analyser.fftSize = 512;
+  dataArray = new Float32Array(analyser.fftSize);
+  source.connect(analyser);
+  const threshold = 0.02; // energy threshold
+
+  const update = () => {
+    if (!analyser) return;
+    analyser.getFloatTimeDomainData(dataArray as any);
+    let sum = 0;
+    for (let i = 0; i < dataArray.length; i++) {
+      const v = dataArray[i];
+      sum += v * v;
+    }
+    const rms = Math.sqrt(sum / dataArray.length);
+    const isSpeaking = rms > threshold;
+
+    if (isSpeaking !== speaking) {
+      speaking = isSpeaking;
+      if (!pressed && !muted) {
+        if (speaking) enableTrack();
+        else disableTrack();
+      }
+      indicator?.classList.toggle('speaking', pressed || speaking);
+    }
+
+    rafId = requestAnimationFrame(update);
+  };
+
+  update();
+}
+
+export function disposeVoicePTT() {
+  if (rafId) cancelAnimationFrame(rafId);
+  window.removeEventListener('keydown', onKeyDown);
+  window.removeEventListener('keyup', onKeyUp);
+  stream?.getTracks().forEach((t) => t.stop());
+  stream = null;
+  sender = null;
+  pc = null;
+  indicator?.classList.remove('speaking');
 }

--- a/tests/VoicePTT.test.ts
+++ b/tests/VoicePTT.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { initVoicePTT, startPushToTalk, setMuted } from 'src/comms/VoicePTT';
+
+describe('VoicePTT moderation', () => {
+  let replaceSpy: any;
+  let addTrackSpy: any;
+
+  beforeEach(() => {
+    replaceSpy = vi.fn();
+    addTrackSpy = vi.fn(() => ({ replaceTrack: replaceSpy }));
+    const pcMock = {
+      addTrack: addTrackSpy,
+    } as any;
+
+    (navigator.mediaDevices as any) = {
+      getUserMedia: vi.fn().mockResolvedValue({
+        getAudioTracks: () => [{ stop: vi.fn() }],
+      }),
+    };
+
+    initVoicePTT(pcMock as any);
+  });
+
+  it('removes track on mute and blocks further sends until unmuted', async () => {
+    await startPushToTalk();
+    expect(addTrackSpy).toHaveBeenCalledTimes(1);
+    setMuted(true);
+    expect(replaceSpy).toHaveBeenLastCalledWith(null);
+    await startPushToTalk();
+    expect(addTrackSpy).toHaveBeenCalledTimes(1);
+    setMuted(false);
+    await startPushToTalk();
+    expect(replaceSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement WebRTC push-to-talk voice module with VAD and mute handling
- add Playwright config for fake media device and voice PTT e2e test
- cover mute behavior with unit test

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm e2e` *(voice-ptt spec not executed, investigate)*

------
https://chatgpt.com/codex/tasks/task_e_689d58d17ed4832fa450c7e90fff2dac