### PR TITLE
Implement rules engine and WebRTC utilities

### DIFF
--- a/src/gameAPI/rulesEngine.ts
+++ b/src/gameAPI/rulesEngine.ts
@@ -1,10 +1,22 @@
+import { getGame } from './index';
+
 /**
- * Centralised rules enforcement. This module can be extended to
- * automatically reject illegal actions, resolve dealer behaviour and
- * produce audit trails. For now it simply returns true for any
- * attempted action.
+ * Centralised rules enforcement. Looks up the registered game by slug and
+ * delegates validation to the game's own rule set. The state object is
+ * expected to contain a `slug` property identifying the game. If the game is
+ * unknown or throws during validation the action is rejected.
  */
 export function enforceRules(state: unknown, action: unknown): boolean {
-  // TODO: validate action based on current state
-  return true;
+  if (!state || typeof state !== 'object') return false;
+  const slug = (state as { slug?: unknown }).slug;
+  if (typeof slug !== 'string') return false;
+  const game = getGame(slug);
+  if (!game || !game.rules || typeof game.rules.validate !== 'function') {
+    return false;
+  }
+  try {
+    return !!game.rules.validate(state, action);
+  } catch {
+    return false;
+  }
 }

--- a/src/net/webrtc.ts
+++ b/src/net/webrtc.ts
@@ -1,9 +1,18 @@
 /**
- * WebRTC utilities. In the early stage of this project the
- * implementation is kept as a stub. The real networking code will
- * establish peer connections using the supplied ICE servers and
- * signalling configuration defined in the product specification.
+ * WebRTC utilities. Provides a thin wrapper around {@link RTCPeerConnection}
+ * that initialises a connection with sensible defaults and basic recovery for
+ * failed connections. When run in a non‑browser environment where WebRTC is not
+ * available the function returns `null`.
  */
-export function setupPeerConnection(): void {
-  // TODO: implement WebRTC set‑up once multiplayer core is being built.
+export function setupPeerConnection(
+  config: RTCConfiguration = {
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+  },
+): RTCPeerConnection | null {
+  if (typeof RTCPeerConnection === 'undefined') return null;
+  const pc = new RTCPeerConnection(config);
+  pc.onconnectionstatechange = () => {
+    if (pc.connectionState === 'failed') pc.restartIce();
+  };
+  return pc;
 }

--- a/tests/rulesEngine.test.ts
+++ b/tests/rulesEngine.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { registerGame } from 'src/gameAPI';
+import { enforceRules } from 'src/gameAPI/rulesEngine';
+import type { GameRegistration } from 'src/gameAPI';
+
+describe('rulesEngine', () => {
+  const slug = 'rules-test';
+  beforeAll(() => {
+    const game: GameRegistration = {
+      slug,
+      meta: {},
+      createInitialState: () => ({}),
+      applyAction: (s: unknown) => s,
+      getPlayerView: (s: unknown) => s,
+      getNextActions: () => [],
+      rules: {
+        validate: (_state: unknown, action: unknown) => action === 'ok',
+      },
+    };
+    registerGame(game);
+  });
+
+  it('delegates to game rules', () => {
+    const state = { slug };
+    expect(enforceRules(state, 'ok')).toBe(true);
+    expect(enforceRules(state, 'bad')).toBe(false);
+  });
+
+  it('returns false for unknown game', () => {
+    const state = { slug: 'missing-game' };
+    expect(enforceRules(state, 'ok')).toBe(false);
+  });
+
+  it('returns false when state lacks slug', () => {
+    expect(enforceRules({}, 'ok')).toBe(false);
+  });
+});

--- a/tests/webrtc.test.ts
+++ b/tests/webrtc.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { setupPeerConnection } from 'src/net/webrtc';
+
+describe('setupPeerConnection', () => {
+  it('creates a peer connection with default ICE servers', () => {
+    class MockRTCPeerConnection {
+      public config: RTCConfiguration;
+      public connectionState: RTCPeerConnectionState = 'new';
+      public restarted = false;
+      onconnectionstatechange: (() => void) | null = null;
+      constructor(config: RTCConfiguration) {
+        this.config = config;
+      }
+      restartIce() {
+        this.restarted = true;
+      }
+    }
+    const original = (globalThis as any).RTCPeerConnection;
+    (globalThis as any).RTCPeerConnection = MockRTCPeerConnection as any;
+
+    const pc = setupPeerConnection();
+    expect(pc).toBeInstanceOf(MockRTCPeerConnection);
+    expect((pc as any).config.iceServers?.[0].urls).toBe(
+      'stun:stun.l.google.com:19302',
+    );
+    (pc as any).connectionState = 'failed';
+    (pc as any).onconnectionstatechange?.();
+    expect((pc as any).restarted).toBe(true);
+
+    (globalThis as any).RTCPeerConnection = original;
+  });
+
+  it('returns null when WebRTC is unavailable', () => {
+    const original = (globalThis as any).RTCPeerConnection;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as any).RTCPeerConnection;
+    expect(setupPeerConnection()).toBeNull();
+    (globalThis as any).RTCPeerConnection = original;
+  });
+});


### PR DESCRIPTION
## Summary
- enforce game rules by delegating to registered game modules
- add WebRTC helper that builds and monitors a peer connection
- cover new functionality with unit tests

## Testing
- `pnpm test` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d696d4b8c832f91bc0a442d0e7ecf