### PR TITLE
Refactor connection messaging and dedupe dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,10 @@
   },
   "dependencies": {
     "bad-words": "^4.0.0",
+    "lz4js": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "xxhash-wasm": "^1.1.0",
     "zod": "^4.0.17"
-    "lz4js": "^0.2.0",
-    "zod": "^4.0.17",
-    "xxhash-wasm": "^1.1.0"
   }
 }

--- a/src/comms/TextChat.tsx
+++ b/src/comms/TextChat.tsx
@@ -42,10 +42,11 @@ const TextChat: React.FC = () => {
       const msg: Msg = JSON.parse(ev.data);
       switch (msg.type) {
         case 'HELLO':
+          if (!msg.clientId) break;
           playerIdRef.current = msg.clientId;
           (window as any).__chatId = msg.clientId;
-          sessionStore.join(ROOM_ID, msg.clientId);
-          ws.send(JSON.stringify({ type: 'JOIN', roomId: ROOM_ID }));
+          const joinMsg = sessionStore.join(ROOM_ID, msg.clientId);
+          ws.send(joinMsg);
           break;
         case 'CHAT':
           addMessage({
@@ -66,6 +67,8 @@ const TextChat: React.FC = () => {
     };
 
     return () => {
+      const leaveMsg = sessionStore.leave();
+      if (leaveMsg) ws.send(leaveMsg);
       ws.close();
     };
   }, []);


### PR DESCRIPTION
## Summary
- Remove duplicate `zod` and `xxhash-wasm` entries from package.json
- Use `sessionStore` to send JOIN and LEAVE messages in TextChat
- Guard against missing client IDs when handling HELLO messages

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d69e24984832f9697a6932b163e82