### PR TITLE
feat: add shared money pool integration

### DIFF
--- a/src/games/blackjack/betting.ts
+++ b/src/games/blackjack/betting.ts
@@ -1,0 +1,31 @@
+import type { SettlementOutcome } from '../../store/moneyPool';
+import { economy } from '../../store/economy';
+
+/**
+ * Deduct chips from a player's balance when they place a bet. This simply
+ * proxies to the shared money pool after ensuring the player has a starting
+ * balance.
+ */
+export function placeBet(handId: string, playerId: string, amount: number) {
+  economy.ensurePlayer(playerId);
+  if (!economy.sharedPool.canBet(playerId, amount)) {
+    throw new Error('insufficient balance');
+  }
+  economy.sharedPool.recordBet(handId, playerId, amount);
+}
+
+/**
+ * Settle a blackjack hand and update player balances in the shared pool. The
+ * outcomes array mirrors the API used by `MoneyPool.settle`.
+ */
+export function settleHand(handId: string, outcomes: SettlementOutcome[]) {
+  economy.sharedPool.settle(handId, outcomes);
+}
+
+/**
+ * Convenience accessor for displaying a player's current chip balance.
+ */
+export function getBalance(playerId: string): number {
+  economy.ensurePlayer(playerId);
+  return economy.sharedPool.balances[playerId] ?? 0;
+}

--- a/src/games/blackjack/index.ts
+++ b/src/games/blackjack/index.ts
@@ -1,0 +1,1 @@
+export { placeBet, settleHand, getBalance } from './betting';

--- a/src/store/economy.ts
+++ b/src/store/economy.ts
@@ -1,0 +1,31 @@
+import { createMoneyPool, MoneyPool } from './moneyPool';
+
+export interface Economy {
+  sharedPool: MoneyPool;
+  initialChipsPerPlayer: number;
+  /**
+   * Ensure the given player exists in the money pool with an initial balance.
+   */
+  ensurePlayer(playerId: string): void;
+}
+
+/**
+ * Global economy state for the application. Currently it only exposes a shared
+ * money pool that all games can use for tracking chips. Each new player that
+ * interacts with the pool receives a default stack of chips.
+ */
+export function createEconomy(initialChipsPerPlayer = 1000): Economy {
+  const sharedPool = createMoneyPool();
+  return {
+    sharedPool,
+    initialChipsPerPlayer,
+    ensurePlayer(playerId: string) {
+      if (sharedPool.balances[playerId] === undefined) {
+        sharedPool.buyIn(playerId, initialChipsPerPlayer);
+      }
+    },
+  };
+}
+
+// Default economy instance used by the app.
+export const economy = createEconomy();


### PR DESCRIPTION
## Summary
- create global economy store with shared chip pool and auto buy-in
- add blackjack helpers to record bets and settle hands using the shared pool

## Testing
- `pnpm test` *(fails: Cannot find module 'src/app/HostPanel', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689d77bdb330832fb55635fced19ec75