### PR TITLE
feat: apply theme styling and responsive UI

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -1,0 +1,20 @@
+.app-container {
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  padding: var(--layout-gutter);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+@media (max-width: 40em) {
+  .app-header {
+    flex-direction: column;
+    gap: 0.5rem;
+    text-align: center;
+  }
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import TextChat from '../comms/TextChat';
+import Button from '../ui/Button';
+import Modal from '../ui/Modal';
+import './App.css';
+
+const App: React.FC = () => {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="app-container">
+      <header className="app-header">
+        <h1>DeckArcade</h1>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+      </header>
+      <main>
+        <TextChat />
+      </main>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <h2>Hello</h2>
+        <p>This modal fades in smoothly.</p>
+        <Button variant="secondary" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </Modal>
+    </div>
+  );
+};
+
+export default App;

--- a/src/comms/TextChat.tsx
+++ b/src/comms/TextChat.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Filter } from 'bad-words';
 import { Msg } from '../net/protocol';
 import { sessionStore } from '../store/session';
+import Button from '../ui/Button';
 
 const EMOTES: Record<string, string> = { ':smile:': '🙂' };
 const ROOM_ID = 'test-room';
@@ -99,7 +100,13 @@ const TextChat: React.FC = () => {
   };
 
   return (
-    <div style={{ borderTop: '1px solid #2a2f33', padding: '0.5rem' }}>
+    <div
+      style={{
+        borderTop: '1px solid var(--color-surface-alt)',
+        padding: '0.5rem',
+        background: 'var(--color-surface)',
+      }}
+    >
       <div
         ref={listRef}
         style={{
@@ -121,7 +128,7 @@ const TextChat: React.FC = () => {
       {mutedReason && (
         <div
           data-testid="chat-muted"
-          style={{ color: '#f66', marginBottom: '0.5rem' }}
+          style={{ color: 'var(--color-danger)', marginBottom: '0.5rem' }}
         >
           Muted: {mutedReason}
         </div>
@@ -132,16 +139,24 @@ const TextChat: React.FC = () => {
           type="text"
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
-          style={{ flex: 1, marginRight: '0.5rem' }}
+          style={{
+            flex: 1,
+            marginRight: '0.5rem',
+            background: 'var(--color-surface-alt)',
+            color: 'var(--color-text)',
+            border: '1px solid var(--color-surface-alt)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '0.25rem 0.5rem',
+          }}
           disabled={!!mutedReason}
         />
-        <button
+        <Button
           data-testid="chat-send"
           onClick={sendMessage}
           disabled={!!mutedReason}
         >
           Send
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app/App';
+import './ui/global.css';
 
 // The entry point for the Deck Arcade application. It mounts the
 // root React component into the DOM. We use React's strict mode
@@ -8,5 +9,5 @@ import App from './app/App';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,4 @@
 declare module 'lz4js';
 declare module 'ws';
 declare module '../src/net/signalingServer.mjs';
+declare module '*.css';

--- a/src/ui/Button.css
+++ b/src/ui/Button.css
@@ -1,0 +1,35 @@
+.da-button {
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  border: none;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s ease, transform 0.15s ease;
+  color: var(--color-bg);
+}
+
+.da-button--primary {
+  background: var(--color-accent-primary);
+}
+
+.da-button--primary:hover {
+  background: var(--color-accent-secondary);
+}
+
+.da-button--secondary {
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.da-button--secondary:hover {
+  background: var(--color-surface-alt);
+}
+
+.da-button:active {
+  transform: scale(0.97);
+}
+
+.da-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import './Button.css';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  className = '',
+  ...props
+}) => {
+  return (
+    <button
+      className={`da-button da-button--${variant} ${className}`}
+      {...props}
+    />
+  );
+};
+
+export default Button;

--- a/src/ui/Modal.css
+++ b/src/ui/Modal.css
@@ -1,0 +1,35 @@
+.da-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.3s var(--animation-ease, cubic-bezier(0.4,0,0.2,1));
+}
+
+.da-modal {
+  background: var(--color-surface);
+  color: var(--color-text);
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  max-width: 90vw;
+  animation: scaleIn 0.3s var(--animation-ease, cubic-bezier(0.4,0,0.2,1));
+}
+
+@media (min-width: 40em) {
+  .da-modal {
+    max-width: 32rem;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes scaleIn {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import './Modal.css';
+
+export interface ModalProps {
+  open: boolean;
+  onClose?: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ open, onClose, children }) => {
+  if (!open) return null;
+  return (
+    <div className="da-modal-overlay" onClick={onClose}>
+      <div className="da-modal" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/ui/global.css
+++ b/src/ui/global.css
@@ -1,0 +1,50 @@
+:root {
+  --color-bg: #0a0e10;
+  --color-surface: #121719;
+  --color-surface-alt: #0f1416;
+  --color-accent-primary: #17bebb;
+  --color-accent-secondary: #e94e77;
+  --color-accent-tertiary: #ffc145;
+  --color-text: #eef2f5;
+  --color-muted: #90a4ae;
+  --color-success: #3ddc84;
+  --color-warning: #ffb300;
+  --color-danger: #ff5a5a;
+  --radius-sm: 0.5rem;
+  --radius-md: 1rem;
+  --radius-lg: 1.5rem;
+  --radius-xl: 2rem;
+  --shadow-card: 0 0.75rem 1.75rem rgba(0, 0, 0, 0.35);
+  --font-display: 'Plus Jakarta Sans', system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
+  --font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
+  --layout-max-width: 82.5rem;
+  --layout-gutter: 1rem;
+}
+
+html, body, #root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.5;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  margin-top: 0;
+}
+
+button {
+  font-family: var(--font-body);
+}
+
+@media (max-width: 40em) {
+  h1 {
+    font-size: 1.75rem;
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,3 @@
+export { default as Button } from './Button';
+export { default as Modal } from './Modal';
+export { theme } from './theme';

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,0 +1,52 @@
+export const theme = {
+  colors: {
+    bg: '#0a0e10',
+    surface: '#121719',
+    surfaceAlt: '#0f1416',
+    accentPrimary: '#17bebb',
+    accentSecondary: '#e94e77',
+    accentTertiary: '#ffc145',
+    text: '#eef2f5',
+    muted: '#90a4ae',
+    success: '#3ddc84',
+    warning: '#ffb300',
+    danger: '#ff5a5a',
+    cardFelt: '#0e3b2e',
+  },
+  radius: { sm: '0.5rem', md: '1rem', lg: '1.5rem', xl: '2rem' },
+  shadows: { card: '0 0.75rem 1.75rem rgba(0,0,0,0.35)' },
+  typography: {
+    display: 'Plus Jakarta Sans',
+    body: 'Inter',
+    mono: 'JetBrains Mono',
+    fallbacks: ['system-ui', '-apple-system', 'Segoe UI', 'Arial'],
+  },
+  spaceScale: [
+    '0',
+    '0.25rem',
+    '0.5rem',
+    '0.75rem',
+    '1rem',
+    '1.5rem',
+    '2rem',
+    '3rem',
+  ],
+  layout: {
+    maxWidth: '82.5rem',
+    gutter: '1rem',
+    breakpoints: {
+      xs: '22.5em',
+      sm: '40em',
+      md: '48em',
+      lg: '64em',
+      xl: '80em',
+    },
+  },
+  animations: {
+    durationMs: { xFast: 90, fast: 150, base: 220, slow: 320, xSlow: 500 },
+    easings: {
+      inOut: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    },
+  },
+};
+export default theme;


### PR DESCRIPTION
## Summary
- add global theme tokens and typography
- introduce themed Button and Modal components
- refresh TextChat and layout with responsive styling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "src/app/HostPanel" etc.)*
- `pnpm typecheck` *(fails: Cannot find module 'src/app/HostPanel' and others)*

------
https://chatgpt.com/codex/tasks/task_e_689d77ca052c832fb405c73d0c825a31