### PR TITLE
feat: add light and dark theme toggle

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+function applyTheme(theme: Theme) {
+  document.body.classList.remove('light', 'dark');
+  document.body.classList.add(theme);
+}
+
+export default function App() {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+      applyTheme(stored);
+    } else {
+      const prefersDark = window.matchMedia
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : false;
+      const initial: Theme = prefersDark ? 'dark' : 'light';
+      setTheme(initial);
+      applyTheme(initial);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    applyTheme(next);
+    localStorage.setItem('theme', next);
+  };
+
+  return (
+    <div>
+      <header>
+        <button className="theme-toggle" onClick={toggleTheme}>
+          {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+        </button>
+      </header>
+      <main>
+        <h1>Deck Arcade</h1>
+        <p>The current theme is {theme} mode.</p>
+        <div className="table">Table preview</div>
+      </main>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app/App';
+import './theme.css';
 
 // The entry point for the Deck Arcade application. It mounts the
 // root React component into the DOM. We use React's strict mode
@@ -8,5 +9,5 @@ import App from './app/App';
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,0 +1,53 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+  --accent-color: #ff6b6b;
+  --background-color: #ffffff;
+  --text-color: #111111;
+  --table-felt-color: #3f9e3f;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    --background-color: #121212;
+    --text-color: #f0f0f0;
+    --table-felt-color: #0a5f0a;
+  }
+}
+
+body.light {
+  color-scheme: light;
+  --background-color: #ffffff;
+  --text-color: #111111;
+  --table-felt-color: #3f9e3f;
+}
+
+body.dark {
+  color-scheme: dark;
+  --background-color: #121212;
+  --text-color: #f0f0f0;
+  --table-felt-color: #0a5f0a;
+}
+
+button.theme-toggle {
+  background-color: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.table {
+  background-color: var(--table-felt-color);
+  padding: 1rem;
+  border-radius: 4px;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add App component with persistent theme switch and system preference detection
- define light and dark color palettes with CSS variables
- wire theme styles into application entry

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve import "src/app/HostPanel" from "tests/HostPanel.test.tsx". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_689d77d04cb4832f83671a167e0a3e50