### PR TITLE
feat: add lobby and host control helpers

### DIFF
--- a/src/net/protocol.js
+++ b/src/net/protocol.js
@@ -33,6 +33,9 @@ export const MsgSchema = z.discriminatedUnion('type', [
     playerId: z.string(),
     ready: z.boolean(),
   }),
+  z.object({ type: z.literal('PAUSE'), roomId: z.string().optional() }),
+  z.object({ type: z.literal('RESUME'), roomId: z.string().optional() }),
+  z.object({ type: z.literal('END_GAME'), roomId: z.string().optional() }),
   z.object({
     type: z.literal('INTENT'),
     playerId: z.string(),

--- a/src/net/protocol.ts
+++ b/src/net/protocol.ts
@@ -45,6 +45,11 @@ export const MsgSchema = z.discriminatedUnion('type', [
     ready: z.boolean(),
   }),
 
+  // Host control messages
+  z.object({ type: z.literal('PAUSE'), roomId: z.string().optional() }),
+  z.object({ type: z.literal('RESUME'), roomId: z.string().optional() }),
+  z.object({ type: z.literal('END_GAME'), roomId: z.string().optional() }),
+
   // Intent messages are sent in lockstep with a sequence number
   z.object({
     type: z.literal('INTENT'),


### PR DESCRIPTION
## Summary
- track player ready and spectator state in session store
- add host control helpers for pausing, resuming and ending games
- extend protocol with PAUSE, RESUME and END_GAME messages

## Testing
- `npm test` *(fails: Cannot resolve imports for app/game modules)*

------
https://chatgpt.com/codex/tasks/task_e_689d77eb0364832fae471a3218652ce0