### PR TITLE
feat: integrate war and solitaire games

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@
 "src/games/blackjack/index.ts",
 "src/games/blackjack/ui.tsx",
 "src/games/blackjack/rules.ts",
-"src/games/hearts/index.ts  (to be added later)",
-"src/games/spades/index.ts  (to be added later)"
+"src/games/hearts/index.ts (to be added later)",
+"src/games/spades/index.ts (to be added later)"
 ]
 }
 },
@@ -316,8 +316,7 @@
 "status": "external-module"
 },
 {
-"slug": "war",
-"title": "War",
+"slug": "title": "War",
 "thumbnail": "/img/games/war/thumb.jpg",
 "short": "The simplest showdown—now with speed rounds.",
 "cta": { "label": "Open", "href": "/games/war" },
@@ -375,13 +374,13 @@
 ],
 "rulesSummary": "High card takes the pile; ties trigger 'war' with burn-and-battle.",
 "cta": { "label": "Open", "href": "/games/war" },
-"status": "external-module"
+"status": "available"
 },
 { "slug": "hearts", "title": "Hearts", "route": "/games/hearts", "players": "4", "difficulty": "Medium", "tags": \["trick-taking"], "cta": { "label": "Open", "href": "/games/hearts" }, "status": "external-module" },
 { "slug": "spades", "title": "Spades", "route": "/games/spades", "players": "4", "difficulty": "Medium", "tags": \["trick-taking", "team"], "cta": { "label": "Open", "href": "/games/spades" }, "status": "external-module" },
 { "slug": "gin-rummy", "title": "Gin Rummy", "route": "/games/gin-rummy", "players": "2", "difficulty": "Medium", "cta": { "label": "Open", "href": "/games/gin-rummy" }, "status": "external-module" },
 { "slug": "crazy-eights", "title": "Crazy Eights", "route": "/games/crazy-eights", "players": "2–6", "difficulty": "Easy", "tags": \["shedding", "family"], "cta": { "label": "Open", "href": "/games/crazy-eights" }, "status": "external-module" },
-{ "slug": "solitaire-klondike", "title": "Solitaire (Klondike)", "route": "/games/solitaire-klondike", "players": "1", "difficulty": "Easy", "cta": { "label": "Open", "href": "/games/solitaire-klondike" }, "status": "external-module" },
+{ "slug": "solitaire-klondike", "title": "Solitaire (Klondike)", "route": "/games/solitaire-klondike", "players": "1", "difficulty": "Easy", "cta": { "label": "Open", "href": "/games/solitaire-klondike" }, "status": "available" },
 { "slug": "euchre", "title": "Euchre", "route": "/games/euchre", "players": "4", "difficulty": "Medium", "tags": \["trick-taking", "team"], "cta": { "label": "Open", "href": "/games/euchre" }, "status": "external-module" },
 { "slug": "baccarat", "title": "Baccarat", "route": "/games/baccarat", "players": "1–7", "difficulty": "Easy", "cta": { "label": "Open", "href": "/games/baccarat" }, "status": "external-module" },
 { "slug": "cribbage", "title": "Cribbage", "route": "/games/cribbage", "players": "2", "difficulty": "Medium", "cta": { "label": "Open", "href": "/games/cribbage" }, "status": "external-module" },
@@ -431,7 +430,7 @@
 "multiplayer": { "maxSeats": 7, "spectators": true, "sharedShoe": true },
 "animations": \["dealCard", "flipCard", "chipSlide", "chipStackBounce", "highlightPulse"]
 },
-"\_comment\_for\_future\_games": "Add each game's schema here (rules + explainers + animations). Host Panel auto-renders controls per schema."
+"\_comment_for_future_games": "Add each game's schema here (rules + explainers + animations). Host Panel auto-renders controls per schema."
 },
 "gameAPI": {
 "contract": {
@@ -516,12 +515,10 @@
 "items": \[
 "blackjack",
 "poker-holdem",
-"war",
 "hearts",
 "spades",
 "gin-rummy",
 "crazy-eights",
-"solitaire-klondike",
 "euchre",
 "baccarat",
 "cribbage",
@@ -529,15 +526,13 @@
 ]
 },
 "gameRegistry": {
-"available": \["blackjack"],
+"available": \["blackjack", "war", "solitaire-klondike"],
 "externalModules": \[
 "poker-holdem",
-"war",
 "hearts",
 "spades",
 "gin-rummy",
 "crazy-eights",
-"solitaire-klondike",
 "euchre",
 "baccarat",
 "cribbage",

--- a/src/gameAPI/index.ts
+++ b/src/gameAPI/index.ts
@@ -1,0 +1,25 @@
+export interface GameRegistration<
+  State = any,
+  Action = any,
+  PlayerId = string,
+> {
+  slug: string;
+  meta: Record<string, any>;
+  createInitialState: (...args: any[]) => State;
+  applyAction: (state: State, action: Action, playerId?: PlayerId) => void;
+  getPlayerView: (state: State, playerId: PlayerId) => unknown;
+  getNextActions: (state: State, playerId: PlayerId) => Action[];
+  rules: {
+    validate: (state: State, action: Action, playerId?: PlayerId) => boolean;
+  };
+}
+
+const registry = new Map<string, GameRegistration>();
+
+export function registerGame(game: GameRegistration): void {
+  registry.set(game.slug, game);
+}
+
+export function getGame(slug: string): GameRegistration | undefined {
+  return registry.get(slug);
+}

--- a/src/gameAPI/rulesEngine.ts
+++ b/src/gameAPI/rulesEngine.ts
@@ -1,0 +1,16 @@
+import { getGame } from './index';
+
+export function enforceRules(
+  state: any,
+  action: any,
+  playerId?: string,
+): boolean {
+  if (!state || typeof state.slug !== 'string') return false;
+  const game = getGame(state.slug);
+  if (!game) return false;
+  try {
+    return game.rules.validate(state, action, playerId);
+  } catch {
+    return false;
+  }
+}

--- a/src/games/solitaire/index.ts
+++ b/src/games/solitaire/index.ts
@@ -1,0 +1,21 @@
+import { registerGame } from '../../gameAPI';
+import {
+  createInitialState,
+  validateAction,
+  applyAction,
+  getHint,
+} from './rules';
+
+registerGame({
+  slug: 'solitaire-klondike',
+  meta: { name: 'Solitaire' },
+  createInitialState,
+  applyAction: (state, action) => applyAction(state as any, action as any),
+  getPlayerView: (state) => state,
+  getNextActions: () => [],
+  rules: {
+    validate: (state, action) => validateAction(state as any, action as any),
+  },
+});
+
+export { createInitialState, validateAction, applyAction, getHint };

--- a/src/games/solitaire/rules.ts
+++ b/src/games/solitaire/rules.ts
@@ -1,0 +1,250 @@
+export type Suit = 'C' | 'D' | 'H' | 'S';
+export interface Card {
+  rank: number; // 1-13
+  suit: Suit;
+  faceUp: boolean;
+}
+
+export interface Piles {
+  stock: Card[];
+  waste: Card[];
+  foundations: Record<Suit, Card[]>;
+  tableau: Card[][]; // 7 piles
+}
+
+export interface GameState {
+  piles: Piles;
+  drawMode: 'draw-1' | 'draw-3';
+  maxRedeals: number;
+  redealsUsed: number;
+  score: number;
+  history: GameStateSnapshot[];
+  future: GameStateSnapshot[];
+  isWon: boolean;
+  slug?: string;
+}
+
+interface GameStateSnapshot {
+  piles: Piles;
+  redealsUsed: number;
+  score: number;
+  isWon: boolean;
+}
+
+function cloneState(state: GameState): GameStateSnapshot {
+  return JSON.parse(
+    JSON.stringify({
+      piles: state.piles,
+      redealsUsed: state.redealsUsed,
+      score: state.score,
+      isWon: state.isWon,
+    }),
+  );
+}
+
+function restoreState(target: GameState, snap: GameStateSnapshot): void {
+  target.piles = snap.piles;
+  target.redealsUsed = snap.redealsUsed;
+  target.score = snap.score;
+  target.isWon = snap.isWon;
+}
+
+function seededRng(seed: number): () => number {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createDeck(): Card[] {
+  const suits: Suit[] = ['C', 'D', 'H', 'S'];
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (let rank = 1; rank <= 13; rank++)
+      deck.push({ rank, suit, faceUp: false });
+  }
+  return deck;
+}
+
+export function createInitialState(
+  seed = Date.now(),
+  options: { drawMode?: 'draw-1' | 'draw-3'; maxRedeals?: number } = {},
+): GameState {
+  const rng = seededRng(seed);
+  const deck = createDeck();
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  const tableau: Card[][] = Array.from({ length: 7 }, () => []);
+  let index = 0;
+  for (let i = 0; i < 7; i++) {
+    for (let j = 0; j <= i; j++) {
+      const card = deck[index++];
+      card.faceUp = j === i;
+      tableau[i].push(card);
+    }
+  }
+  const stock = deck.slice(index);
+  const waste: Card[] = [];
+  const foundations: Record<Suit, Card[]> = { C: [], D: [], H: [], S: [] };
+  return {
+    piles: { stock, waste, foundations, tableau },
+    drawMode: options.drawMode ?? 'draw-1',
+    maxRedeals: options.maxRedeals ?? Infinity,
+    redealsUsed: 0,
+    score: 0,
+    history: [],
+    future: [],
+    isWon: false,
+    slug: 'solitaire-klondike',
+  };
+}
+
+function color(suit: Suit): 'red' | 'black' {
+  return suit === 'C' || suit === 'S' ? 'black' : 'red';
+}
+
+export type Action =
+  | { type: 'MOVE'; from: any; to: any }
+  | { type: 'REDEPLOY_STOCK' }
+  | { type: 'FLIP_TABLEAU_TOP'; pileIndex: number }
+  | { type: 'UNDO' }
+  | { type: 'REDO' }
+  | { type: 'DRAW_STOCK' };
+
+export function validateAction(state: GameState, action: Action): boolean {
+  switch (action.type) {
+    case 'MOVE': {
+      const { from, to } = action;
+      if (from.type === 'tableau' && to.type === 'tableau') {
+        const src = state.piles.tableau[from.index];
+        const dst = state.piles.tableau[to.index];
+        const card = src[src.length - 1];
+        if (!card || !card.faceUp) return false;
+        const top = dst[dst.length - 1];
+        if (!top) return card.rank === 13; // king on empty
+        return (
+          color(card.suit) !== color(top.suit) && card.rank === top.rank - 1
+        );
+      } else if (from.type === 'waste' && to.type === 'foundation') {
+        const card = state.piles.waste[state.piles.waste.length - 1];
+        if (!card) return false;
+        if (card.suit !== to.suit) return false;
+        const foundation = state.piles.foundations[to.suit];
+        return card.rank === foundation.length + 1;
+      }
+      return false;
+    }
+    case 'REDEPLOY_STOCK':
+      return (
+        state.piles.stock.length === 0 &&
+        state.piles.waste.length > 0 &&
+        state.redealsUsed < state.maxRedeals
+      );
+    case 'FLIP_TABLEAU_TOP': {
+      const pile = state.piles.tableau[action.pileIndex];
+      if (!pile.length) return false;
+      const card = pile[pile.length - 1];
+      return !card.faceUp;
+    }
+    case 'UNDO':
+      return state.history.length > 0;
+    case 'REDO':
+      return state.future.length > 0;
+    case 'DRAW_STOCK':
+      return state.piles.stock.length > 0;
+    default:
+      return false;
+  }
+}
+
+function checkWin(state: GameState): void {
+  const f = state.piles.foundations;
+  state.isWon =
+    f.C.length === 13 &&
+    f.D.length === 13 &&
+    f.H.length === 13 &&
+    f.S.length === 13;
+}
+
+export function applyAction(state: GameState, action: Action): void {
+  if (action.type !== 'UNDO' && action.type !== 'REDO') {
+    state.history.push(cloneState(state));
+    state.future = [];
+  }
+  switch (action.type) {
+    case 'MOVE': {
+      const { from, to } = action;
+      if (from.type === 'tableau' && to.type === 'tableau') {
+        const card = state.piles.tableau[from.index].pop()!;
+        state.piles.tableau[to.index].push(card);
+      } else if (from.type === 'waste' && to.type === 'foundation') {
+        const card = state.piles.waste.pop()!;
+        state.piles.foundations[to.suit].push(card);
+        state.score += 10;
+        checkWin(state);
+      }
+      break;
+    }
+    case 'REDEPLOY_STOCK': {
+      state.piles.stock = state.piles.waste
+        .reverse()
+        .map((c) => ({ ...c, faceUp: false }));
+      state.piles.waste = [];
+      state.redealsUsed += 1;
+      break;
+    }
+    case 'FLIP_TABLEAU_TOP': {
+      const pile = state.piles.tableau[action.pileIndex];
+      const card = pile[pile.length - 1];
+      if (card && !card.faceUp) {
+        card.faceUp = true;
+        state.score += 5;
+      }
+      break;
+    }
+    case 'UNDO': {
+      const snap = state.history.pop();
+      if (snap) {
+        state.future.push(cloneState(state));
+        restoreState(state, snap);
+      }
+      break;
+    }
+    case 'REDO': {
+      const snap = state.future.pop();
+      if (snap) {
+        state.history.push(cloneState(state));
+        restoreState(state, snap);
+      }
+      break;
+    }
+    case 'DRAW_STOCK': {
+      const count = state.drawMode === 'draw-3' ? 3 : 1;
+      for (let i = 0; i < count && state.piles.stock.length; i++) {
+        const card = state.piles.stock.pop()!;
+        card.faceUp = true;
+        state.piles.waste.push(card);
+      }
+      break;
+    }
+  }
+}
+
+export function getHint(state: GameState): { from: any; to: any } | undefined {
+  const wasteCard = state.piles.waste[state.piles.waste.length - 1];
+  if (wasteCard) {
+    const foundation = state.piles.foundations[wasteCard.suit];
+    if (wasteCard.rank === foundation.length + 1) {
+      return {
+        from: { type: 'waste' },
+        to: { type: 'foundation', suit: wasteCard.suit },
+      };
+    }
+  }
+  return undefined;
+}

--- a/src/games/solitaire/ui.tsx
+++ b/src/games/solitaire/ui.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  createInitialState,
+  applyAction,
+  validateAction,
+  getHint,
+  type Action,
+} from './rules';
+
+export default function SolitaireGame() {
+  const [state, setState] = React.useState(() => createInitialState());
+
+  const dispatch = (action: Action) => {
+    if (validateAction(state, action)) {
+      applyAction(state, action);
+      setState({ ...state });
+    }
+  };
+
+  const draw = () => dispatch({ type: 'DRAW_STOCK' });
+
+  const hint = () => {
+    const h = getHint(state);
+    if (h) dispatch({ type: 'MOVE', from: h.from, to: h.to } as any);
+  };
+
+  return (
+    <div>
+      <button onClick={draw}>Draw</button>
+      <button onClick={hint}>Hint</button>
+      <div>Score: {state.score}</div>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        {state.piles.tableau.map((pile, i) => (
+          <div key={i}>
+            {pile.map((c) => (c.faceUp ? c.rank : 'X')).join(' ')}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/games/war/index.ts
+++ b/src/games/war/index.ts
@@ -1,0 +1,16 @@
+import { registerGame } from '../../gameAPI';
+import { createInitialState, applyAction, getPlayerView } from './rules';
+
+registerGame({
+  slug: 'war',
+  meta: { name: 'War' },
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions: () => ['draw'],
+  rules: {
+    validate: (_state, action) => action === 'draw',
+  },
+});
+
+export { createInitialState, applyAction, getPlayerView };

--- a/src/games/war/rules.ts
+++ b/src/games/war/rules.ts
@@ -1,0 +1,121 @@
+export type Rank =
+  | 'A'
+  | 'K'
+  | 'Q'
+  | 'J'
+  | '10'
+  | '9'
+  | '8'
+  | '7'
+  | '6'
+  | '5'
+  | '4'
+  | '3'
+  | '2';
+export type Suit = 'C' | 'D' | 'H' | 'S';
+export interface Card {
+  rank: Rank;
+  suit: Suit;
+}
+
+export interface GameState {
+  deck: Card[];
+  warPile?: Card[];
+  lastDraw?: { p1: Card; p2: Card };
+  winner?: 'p1' | 'p2' | 'war';
+}
+
+const rankOrder: Rank[] = [
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'J',
+  'Q',
+  'K',
+  'A',
+];
+
+export function createDeck(): Card[] {
+  const suits: Suit[] = ['C', 'D', 'H', 'S'];
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (const rank of rankOrder) deck.push({ rank, suit });
+  }
+  return deck;
+}
+
+export function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+export function createInitialState(): GameState {
+  return { deck: shuffle(createDeck()) };
+}
+
+function value(rank: Rank): number {
+  return rankOrder.indexOf(rank);
+}
+
+export function applyAction(state: GameState, action: 'draw'): void {
+  if (action !== 'draw') return;
+  if (state.winner === 'war') {
+    // Resolve ongoing war
+    // burn 3 cards each if possible
+    const warPile = state.warPile ?? [];
+    const burnCount = Math.min(3, Math.floor(state.deck.length / 2));
+    for (let i = 0; i < burnCount; i++) {
+      warPile.push(state.deck.pop()!); // p1 burn
+      warPile.push(state.deck.pop()!); // p2 burn
+    }
+    if (state.deck.length < 2) {
+      state.warPile = warPile;
+      return;
+    }
+    const p1 = state.deck.pop()!;
+    const p2 = state.deck.pop()!;
+    warPile.push(p1, p2);
+    state.lastDraw = { p1, p2 };
+    const v1 = value(p1.rank);
+    const v2 = value(p2.rank);
+    if (v1 > v2) state.winner = 'p1';
+    else if (v2 > v1) state.winner = 'p2';
+    else {
+      state.winner = 'war';
+      state.warPile = warPile;
+    }
+    if (state.winner !== 'war') {
+      state.warPile = undefined;
+    }
+    return;
+  }
+  if (state.deck.length < 2) return;
+  const p1 = state.deck.pop()!;
+  const p2 = state.deck.pop()!;
+  state.lastDraw = { p1, p2 };
+  const v1 = value(p1.rank);
+  const v2 = value(p2.rank);
+  if (v1 > v2) state.winner = 'p1';
+  else if (v2 > v1) state.winner = 'p2';
+  else {
+    state.winner = 'war';
+    state.warPile = [p1, p2];
+  }
+}
+
+export function getPlayerView(
+  state: GameState,
+  _playerId: string,
+): Omit<GameState, 'deck'> & { deckCount: number } {
+  const { deck, ...rest } = state;
+  return { ...rest, deckCount: deck.length };
+}

--- a/src/games/war/ui.tsx
+++ b/src/games/war/ui.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createInitialState, applyAction, getPlayerView } from './rules';
+
+export default function WarGame() {
+  const [state, setState] = React.useState(() => createInitialState());
+  const view = getPlayerView(state, 'p1');
+
+  const draw = () => {
+    applyAction(state, 'draw');
+    setState({ ...state });
+  };
+
+  return (
+    <div>
+      <button onClick={draw}>Draw</button>
+      {state.lastDraw && (
+        <div>
+          <div>P1: {state.lastDraw.p1.rank}</div>
+          <div>P2: {state.lastDraw.p2.rank}</div>
+          <div>Winner: {state.winner}</div>
+        </div>
+      )}
+      <div>Deck remaining: {view.deckCount}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add game API registry and rules engine
- implement War and Solitaire game logic with basic UIs
- enable War and Solitaire in game registry

## Testing
- `npx vitest run tests/gameAPI.test.ts tests/rulesEngine.test.ts tests/games/war/rules.test.ts tests/games/solitaire/rules.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689d77f41834832f9799c507ab626a8d