### PR TITLE
Add Sueca game rules and tests

### DIFF
--- a/src/games/sueca/rules.ts
+++ b/src/games/sueca/rules.ts
@@ -1,0 +1,156 @@
+export type Suit = 'C' | 'D' | 'H' | 'S';
+export type Rank = 'A' | '7' | 'K' | 'J' | 'Q' | '6' | '5' | '4' | '3' | '2';
+export interface Card {
+  suit: Suit;
+  rank: Rank;
+}
+
+const ORDER: Rank[] = ['A', '7', 'K', 'J', 'Q', '6', '5', '4', '3', '2'];
+const POINTS: Record<Rank, number> = {
+  A: 11,
+  '7': 10,
+  K: 4,
+  J: 3,
+  Q: 2,
+  '6': 0,
+  '5': 0,
+  '4': 0,
+  '3': 0,
+  '2': 0,
+};
+
+export const createDeck = (): Card[] => {
+  const suits: Suit[] = ['C', 'D', 'H', 'S'];
+  const deck: Card[] = [];
+  for (const suit of suits) {
+    for (const rank of ORDER) {
+      deck.push({ suit, rank });
+    }
+  }
+  return deck;
+};
+
+export interface DealResult {
+  hands: Card[][];
+  trump: Suit;
+}
+
+export const deal = (deck: Card[]): DealResult => {
+  if (deck.length !== 40) throw new Error('deck must have 40 cards');
+  const hands: Card[][] = [[], [], [], []];
+  for (let i = 0; i < deck.length; i++) {
+    hands[i % 4].push(deck[i]);
+  }
+  const trump = hands[3][hands[3].length - 1].suit;
+  return { hands, trump };
+};
+
+const orderIndex = (rank: Rank): number => ORDER.indexOf(rank);
+
+export const getCardPoints = (card: Card): number => POINTS[card.rank];
+
+export const compareCards = (
+  a: Card,
+  b: Card,
+  lead: Suit,
+  trump: Suit,
+): number => {
+  if (a.suit === b.suit) {
+    return orderIndex(b.rank) - orderIndex(a.rank);
+  }
+  if (a.suit === trump && b.suit !== trump) return 1;
+  if (b.suit === trump && a.suit !== trump) return -1;
+  if (a.suit === lead && b.suit !== lead) return 1;
+  if (b.suit === lead && a.suit !== lead) return -1;
+  return 0;
+};
+
+export const getTrickWinner = (trick: Card[], trump: Suit): number => {
+  const lead = trick[0].suit;
+  let winner = 0;
+  for (let i = 1; i < trick.length; i++) {
+    if (compareCards(trick[i], trick[winner], lead, trump) > 0) {
+      winner = i;
+    }
+  }
+  return winner;
+};
+
+export const trickPoints = (trick: Card[]): number =>
+  trick.reduce((sum, c) => sum + getCardPoints(c), 0);
+
+export interface GameState {
+  hands: Card[][];
+  trick: Card[];
+  leader: number;
+  trump: Suit;
+  scores: [number, number];
+  mustTrumpWhenVoid: boolean;
+}
+
+export const createInitialState = (
+  deck: Card[] = createDeck(),
+  opts: { dealer?: number; mustTrumpWhenVoid?: boolean } = {},
+): GameState => {
+  const dealer = opts.dealer ?? 3;
+  const { hands, trump } = deal(deck);
+  return {
+    hands,
+    trick: [],
+    leader: (dealer + 1) % 4,
+    trump,
+    scores: [0, 0],
+    mustTrumpWhenVoid: opts.mustTrumpWhenVoid ?? false,
+  };
+};
+
+export const currentPlayer = (state: GameState): number =>
+  (state.leader + state.trick.length) % 4;
+
+export const canPlayCard = (
+  state: GameState,
+  player: number,
+  card: Card,
+): boolean => {
+  if (currentPlayer(state) !== player) return false;
+  const hand = state.hands[player];
+  const idx = hand.findIndex(
+    (c) => c.suit === card.suit && c.rank === card.rank,
+  );
+  if (idx === -1) return false;
+  if (state.trick.length === 0) return true;
+  const lead = state.trick[0].suit;
+  const hasLead = hand.some((c) => c.suit === lead);
+  if (hasLead && card.suit !== lead) return false;
+  if (!hasLead && state.mustTrumpWhenVoid) {
+    const hasTrump = hand.some((c) => c.suit === state.trump);
+    if (hasTrump && card.suit !== state.trump) return false;
+  }
+  return true;
+};
+
+export const playCard = (
+  state: GameState,
+  player: number,
+  card: Card,
+): void => {
+  if (!canPlayCard(state, player, card)) throw new Error('illegal play');
+  const hand = state.hands[player];
+  const idx = hand.findIndex(
+    (c) => c.suit === card.suit && c.rank === card.rank,
+  );
+  hand.splice(idx, 1);
+  state.trick.push(card);
+  if (state.trick.length === 4) {
+    const relWinner = getTrickWinner(state.trick, state.trump);
+    const winner = (state.leader + relWinner) % 4;
+    const points = trickPoints(state.trick);
+    if (winner % 2 === 0) state.scores[0] += points;
+    else state.scores[1] += points;
+    state.trick = [];
+    state.leader = winner;
+  }
+};
+
+export const isHandOver = (state: GameState): boolean =>
+  state.hands[0].length === 0 && state.trick.length === 0;

--- a/tests/games/sueca/rules.test.ts
+++ b/tests/games/sueca/rules.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createDeck,
+  deal,
+  getTrickWinner,
+  trickPoints,
+  canPlayCard,
+  playCard,
+  type Card,
+  type GameState,
+} from 'src/games/sueca/rules';
+
+const card = (rank: Card['rank'], suit: Card['suit']): Card => ({ rank, suit });
+
+describe('sueca deck', () => {
+  it('contains 40 cards without 8s, 9s, or 10s', () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(40);
+    expect(deck.some((c: any) => ['8', '9', '10'].includes(c.rank))).toBe(
+      false,
+    );
+  });
+});
+
+describe('deal and trick logic', () => {
+  it('deals 10 cards each and sets trump from dealer last card', () => {
+    const deck = createDeck();
+    const { hands, trump } = deal(deck);
+    expect(hands.every((h) => h.length === 10)).toBe(true);
+    expect(trump).toBe(hands[3][9].suit);
+  });
+
+  it('evaluates trick winner considering trump and rank order', () => {
+    const trick = [
+      card('K', 'H'),
+      card('A', 'H'),
+      card('2', 'S'),
+      card('7', 'H'),
+    ];
+    expect(getTrickWinner(trick, 'S')).toBe(2);
+    const trick2 = [card('Q', 'D'), card('7', 'D'), card('K', 'C')];
+    expect(getTrickWinner(trick2, 'S')).toBe(1);
+  });
+
+  it('sums trick points correctly', () => {
+    const trick = [card('A', 'S'), card('7', 'H'), card('Q', 'D')];
+    expect(trickPoints(trick)).toBe(11 + 10 + 2);
+  });
+});
+
+describe('play enforcement and scoring', () => {
+  it('enforces follow suit and optional must trump', () => {
+    const state: GameState = {
+      hands: [
+        [card('A', 'H')],
+        [card('K', 'S'), card('Q', 'H')],
+        [card('2', 'D')],
+        [card('3', 'C')],
+      ],
+      trick: [card('A', 'H')],
+      leader: 0,
+      trump: 'S',
+      scores: [0, 0],
+      mustTrumpWhenVoid: false,
+    };
+    expect(canPlayCard(state, 1, card('K', 'S'))).toBe(false);
+    expect(canPlayCard(state, 1, card('Q', 'H'))).toBe(true);
+    state.mustTrumpWhenVoid = true;
+    state.hands[1] = [card('K', 'S'), card('Q', 'C')];
+    expect(canPlayCard(state, 1, card('Q', 'C'))).toBe(false);
+    expect(canPlayCard(state, 1, card('K', 'S'))).toBe(true);
+  });
+
+  it('scores tricks for winning team and rotates leader', () => {
+    const state: GameState = {
+      hands: [
+        [card('A', 'H')],
+        [card('7', 'H')],
+        [card('2', 'C')],
+        [card('3', 'D')],
+      ],
+      trick: [],
+      leader: 0,
+      trump: 'S',
+      scores: [0, 0],
+      mustTrumpWhenVoid: false,
+    };
+    playCard(state, 0, card('A', 'H'));
+    playCard(state, 1, card('7', 'H'));
+    playCard(state, 2, card('2', 'C'));
+    playCard(state, 3, card('3', 'D'));
+    expect(state.scores).toEqual([21, 0]);
+    expect(state.leader).toBe(0);
+    expect(state.trick.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Sueca trick-taking game rules including deck composition, trick comparison, enforcing follow-suit and scoring
- add unit tests covering deck creation, dealing, trick winner evaluation, and scoring mechanics

## Testing
- `pnpm test tests/games/sueca/rules.test.ts`
- `pnpm lint` *(fails: Cannot find module 'src/app/HostPanel' ...)*
- `pnpm typecheck` *(fails: Cannot find module 'src/app/HostPanel' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d78c4effc832f9e3e825e9604d48c