### PR TITLE
Wire games to registry and streamline engines

### DIFF
--- a/src/app/HostPanel.tsx
+++ b/src/app/HostPanel.tsx
@@ -9,10 +9,12 @@ interface Props {
 
 export default function HostPanel({ gameName, gameSettingsSchema }: Props) {
   const { elements, state } = useGameSchema(gameSettingsSchema);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     sessionStore.createTable({ game: gameName, ...state });
   };
+
   return (
     <form onSubmit={handleSubmit}>
       {elements}
@@ -20,117 +22,3 @@ export default function HostPanel({ gameName, gameSettingsSchema }: Props) {
     </form>
   );
 }
-
-import React, { useState } from 'react';
-import { sessionStore } from '../store/session';
-
-interface HostPanelProps {
-  gameName: string;
-  gameSettingsSchema: {
-    properties?: Record<string, any>;
-  };
-}
-
-const HostPanel: React.FC<HostPanelProps> = ({
-  gameName,
-  gameSettingsSchema,
-}) => {
-  const properties = gameSettingsSchema?.properties || {};
-  const [settings, setSettings] = useState<Record<string, any>>({});
-
-  const handleChange = (key: string, value: any) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
-  };
-
-  const renderField = (key: string, schema: any) => {
-    const common: any = {};
-    if (schema.minimum !== undefined) common.min = schema.minimum;
-    if (schema.maximum !== undefined) common.max = schema.maximum;
-    const value = settings[key];
-
-    if (Array.isArray(schema.enum)) {
-      return (
-        <label key={key} style={{ display: 'block', marginBottom: '0.5rem' }}>
-          {key}
-          <select
-            value={value ?? schema.enum[0] ?? ''}
-            onChange={(e) => handleChange(key, e.target.value)}
-            style={{ marginLeft: '0.5rem' }}
-          >
-            {schema.enum.map((opt: any) => (
-              <option key={String(opt)} value={opt}>
-                {String(opt)}
-              </option>
-            ))}
-          </select>
-        </label>
-      );
-    }
-
-    if (schema.type === 'boolean') {
-      return (
-        <label key={key} style={{ display: 'block', marginBottom: '0.5rem' }}>
-          {key}
-          <input
-            type="checkbox"
-            checked={!!value}
-            onChange={(e) => handleChange(key, e.target.checked)}
-            style={{ marginLeft: '0.5rem' }}
-          />
-        </label>
-      );
-    }
-
-    if (schema.type === 'number' || schema.type === 'integer') {
-      return (
-        <label key={key} style={{ display: 'block', marginBottom: '0.5rem' }}>
-          {key}
-          <input
-            type="number"
-            value={value ?? ''}
-            onChange={(e) => handleChange(key, e.target.value)}
-            {...common}
-            style={{ marginLeft: '0.5rem' }}
-          />
-        </label>
-      );
-    }
-
-    return (
-      <label key={key} style={{ display: 'block', marginBottom: '0.5rem' }}>
-        {key}
-        <input
-          type="text"
-          value={value ?? ''}
-          onChange={(e) => handleChange(key, e.target.value)}
-          style={{ marginLeft: '0.5rem' }}
-        />
-      </label>
-    );
-  };
-
-  const startTable = () => {
-    const config: Record<string, any> = {};
-    for (const [key, schema] of Object.entries(properties)) {
-      let value = settings[key];
-      if (schema.type === 'number' || schema.type === 'integer') {
-        const num = Number(value);
-        if (!Number.isNaN(num)) value = num;
-      }
-      config[key] = value;
-    }
-    sessionStore.createTable(config);
-    // Networking and other side effects would be handled here in a full app
-  };
-
-  return (
-    <div>
-      {Object.entries(properties).map(([key, schema]) =>
-        renderField(key, schema),
-      )}
-      <button onClick={startTable}>Start table</button>
-    </div>
-  );
-};
-
-export default HostPanel;

--- a/src/app/useGameSchema.tsx
+++ b/src/app/useGameSchema.tsx
@@ -1,56 +1,3 @@
-import React from 'react';
-
-type Schema = {
-  properties: Record<string, any>;
-};
-
-export default function useGameSchema(schema: Schema) {
-  const elements = React.useMemo(() => {
-    const els: React.ReactNode[] = [];
-    for (const [name, prop] of Object.entries(schema.properties)) {
-      if (prop.type === 'number') {
-        els.push(
-          <label key={name}>
-            {name}
-            <input aria-label={name} type="number" />
-          </label>,
-        );
-      } else if (prop.type === 'boolean') {
-        els.push(
-          <label key={name}>
-            {name}
-            <input aria-label={name} type="checkbox" />
-          </label>,
-        );
-      } else if (prop.enum) {
-        els.push(
-          <label key={name}>
-            {name}
-            <select aria-label={name}>
-              {prop.enum.map((v: string) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-          </label>,
-        );
-      } else if (prop.type === 'array' && prop.items?.enum) {
-        els.push(
-          <div key={name}>
-            {prop.items.enum.map((v: string) => (
-              <label key={v}>
-                {v}
-                <input aria-label={v} type="checkbox" value={v} />
-              </label>
-            ))}
-          </div>,
-        );
-      }
-    }
-    return els;
-  }, [schema]);
-  return { elements };
 import React, { useState } from 'react';
 
 interface Schema {
@@ -59,6 +6,7 @@ interface Schema {
 
 export default function useGameSchema(schema: Schema) {
   const [state, setState] = useState<Record<string, any>>({});
+
   const elements = Object.entries(schema.properties || {}).map(([key, def]) => {
     if (def.type === 'number') {
       return (
@@ -126,5 +74,6 @@ export default function useGameSchema(schema: Schema) {
     }
     return null;
   });
+
   return { elements, state };
 }

--- a/src/gameAPI/animations.ts
+++ b/src/gameAPI/animations.ts
@@ -6,21 +6,10 @@ export type DomainEvent =
   | { type: 'invalid' };
 
 export function handleDomainEvent(event: DomainEvent, el: HTMLElement): void {
-  const mq = window.matchMedia?.('(prefers-reduced-motion: reduce)');
-  if (mq && mq.matches) return;
-  const className = `anim-${event.type}`;
-  el.classList.add(className);
-
-export interface DomainEvent {
-  type: string;
-}
-
-export function handleDomainEvent(event: DomainEvent, el: HTMLElement) {
   const mq =
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)');
   if (mq && mq.matches) return;
   el.classList.add(`anim-${event.type}`);
-
 }

--- a/src/gameAPI/index.ts
+++ b/src/gameAPI/index.ts
@@ -1,36 +1,3 @@
-export interface GameRegistration<State = any, Action = any> {
-  slug: string;
-  meta: Record<string, unknown>;
-  createInitialState: (...args: any[]) => State;
-  applyAction: (state: State, action: Action) => State;
-  getPlayerView: (state: State, playerId: string) => unknown;
-  getNextActions: (state: State, playerId: string) => Action[];
-  rules: {
-    validate: (state: State, action: Action, playerId?: string) => boolean;
-  };
-}
-
-const registry: Record<string, GameRegistration> = {};
-
-export function registerGame(game: GameRegistration): void {
-  registry[game.slug] = game;
-}
-
-export function getGame(slug: string): GameRegistration | undefined {
-  return registry[slug];
-}
-
-export type { GameRegistration as Game };
-
-export interface GameRegistration {
-  slug: string;
-  meta: Record<string, unknown>;
-  createInitialState: (...args: any[]) => unknown;
-  applyAction: (state: any, action: any) => any;
-  getPlayerView: (state: any, playerId?: string) => any;
-  getNextActions: (state: any, stage?: string) => string[];
-  rules: {
-    validate: (state: any, action: any) => boolean;
 export interface GameRegistration<
   State = any,
   Action = any,
@@ -56,3 +23,5 @@ export function registerGame(game: GameRegistration): void {
 export function getGame(slug: string): GameRegistration | undefined {
   return registry.get(slug);
 }
+
+export type Game = GameRegistration;

--- a/src/games/blackjack/index.ts
+++ b/src/games/blackjack/index.ts
@@ -1,1 +1,33 @@
+import { registerGame } from '../../gameAPI';
+import {
+  createInitialState,
+  applyAction,
+  getNextActions,
+  Hand,
+  GameState,
+  BlackjackConfig,
+} from './rules';
+
+registerGame({
+  slug: 'blackjack',
+  meta: { name: 'Blackjack' },
+  createInitialState: (config: BlackjackConfig) => createInitialState(config),
+  applyAction: (state, action) =>
+    applyAction(state as GameState, action as any),
+  getPlayerView: (state) => state,
+  getNextActions: (state) => getNextActions(state as GameState, ''),
+  rules: {
+    validate: (state, action) =>
+      getNextActions(state as GameState, '').includes(action as any),
+  },
+});
+
+export {
+  createInitialState,
+  applyAction,
+  getNextActions,
+  Hand,
+  GameState,
+  BlackjackConfig,
+} from './rules';
 export { placeBet, settleHand, getBalance } from './betting';

--- a/src/games/solitaire/index.ts
+++ b/src/games/solitaire/index.ts
@@ -4,6 +4,7 @@ import {
   validateAction,
   applyAction,
   getHint,
+  getNextActions,
 } from './rules';
 
 registerGame({
@@ -12,10 +13,16 @@ registerGame({
   createInitialState,
   applyAction: (state, action) => applyAction(state as any, action as any),
   getPlayerView: (state) => state,
-  getNextActions: () => [],
+  getNextActions: (state) => getNextActions(state as any),
   rules: {
     validate: (state, action) => validateAction(state as any, action as any),
   },
 });
 
-export { createInitialState, validateAction, applyAction, getHint };
+export {
+  createInitialState,
+  validateAction,
+  applyAction,
+  getHint,
+  getNextActions,
+};

--- a/src/games/solitaire/rules.ts
+++ b/src/games/solitaire/rules.ts
@@ -1,40 +1,23 @@
 export type Suit = 'C' | 'D' | 'H' | 'S';
+
 export interface Card {
-
-  rank: number;
-
   rank: number; // 1-13
-
   suit: Suit;
   faceUp: boolean;
 }
 
-export interface GameState {
-  piles: {
-    stock: Card[];
-    waste: Card[];
-    tableau: Card[][];
-    foundations: Record<Suit, Card[]>;
-  };
-  score: number;
-  redealsUsed: number;
-  maxRedeals: number;
-  prev?: GameState;
-  next?: GameState;
-  isWon: boolean;
-}
-
-function mulberry32(a: number) {
-  return function () {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    var t = Math.imul(a ^ (a >>> 15), 1 | a);
-
 export interface Piles {
   stock: Card[];
   waste: Card[];
-  foundations: Record<Suit, Card[]>;
   tableau: Card[][]; // 7 piles
+  foundations: Record<Suit, Card[]>;
+}
+
+interface GameStateSnapshot {
+  piles: Piles;
+  redealsUsed: number;
+  score: number;
+  isWon: boolean;
 }
 
 export interface GameState {
@@ -45,14 +28,6 @@ export interface GameState {
   score: number;
   history: GameStateSnapshot[];
   future: GameStateSnapshot[];
-  isWon: boolean;
-  slug?: string;
-}
-
-interface GameStateSnapshot {
-  piles: Piles;
-  redealsUsed: number;
-  score: number;
   isWon: boolean;
 }
 
@@ -84,38 +59,20 @@ function seededRng(seed: number): () => number {
   };
 }
 
-function shuffle(seed: number): Card[] {
-  const rng = mulberry32(seed);
-  const suits: Suit[] = ['C', 'D', 'H', 'S'];
-  const deck: Card[] = [];
-  for (let r = 1; r <= 13; r++) {
-    for (const s of suits) deck.push({ rank: r, suit: s, faceUp: false });
-  }
-  for (let i = deck.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [deck[i], deck[j]] = [deck[j], deck[i]];
-
 function createDeck(): Card[] {
   const suits: Suit[] = ['C', 'D', 'H', 'S'];
   const deck: Card[] = [];
   for (const suit of suits) {
-    for (let rank = 1; rank <= 13; rank++)
+    for (let rank = 1; rank <= 13; rank++) {
       deck.push({ rank, suit, faceUp: false });
+    }
   }
   return deck;
 }
 
 export function createInitialState(
-  seed: number,
-  opts: { drawMode?: string; maxRedeals?: number } = {},
-): GameState {
-  const deck = shuffle(seed);
-  const tableau: Card[][] = Array.from({ length: 7 }, () => []);
-  for (let i = 0; i < 7; i++) {
-    for (let j = 0; j <= i; j++) {
-      const card = deck.shift()!;
   seed = Date.now(),
-  options: { drawMode?: 'draw-1' | 'draw-3'; maxRedeals?: number } = {},
+  opts: { drawMode?: 'draw-1' | 'draw-3'; maxRedeals?: number } = {},
 ): GameState {
   const rng = seededRng(seed);
   const deck = createDeck();
@@ -124,16 +81,13 @@ export function createInitialState(
     [deck[i], deck[j]] = [deck[j], deck[i]];
   }
   const tableau: Card[][] = Array.from({ length: 7 }, () => []);
-  let index = 0;
   for (let i = 0; i < 7; i++) {
     for (let j = 0; j <= i; j++) {
-      const card = deck[index++];
-
+      const card = deck.pop()!;
       card.faceUp = j === i;
       tableau[i].push(card);
     }
   }
-
   return {
     piles: {
       stock: deck,
@@ -141,45 +95,84 @@ export function createInitialState(
       tableau,
       foundations: { C: [], D: [], H: [], S: [] },
     },
-    score: 0,
-    redealsUsed: 0,
+    drawMode: opts.drawMode ?? 'draw-1',
     maxRedeals: opts.maxRedeals ?? Infinity,
+    redealsUsed: 0,
+    score: 0,
+    history: [],
+    future: [],
     isWon: false,
   };
 }
 
-function clone(state: GameState): GameState {
-  return JSON.parse(JSON.stringify(state));
-}
-
-function color(suit: Suit) {
+function color(suit: Suit): 'red' | 'black' {
   return suit === 'C' || suit === 'S' ? 'black' : 'red';
 }
 
-export function validateAction(state: GameState, action: any): boolean {
-  if (
-    action.type === 'MOVE' &&
-    action.from.type === 'tableau' &&
-    action.to.type === 'tableau'
-  ) {
-    const fromPile = state.piles.tableau[action.from.index];
-    const toPile = state.piles.tableau[action.to.index];
-    if (!fromPile.length) return false;
-    const card = fromPile[fromPile.length - 1];
-    const target = toPile[toPile.length - 1];
-    if (!target) return false;
-    const allowed =
-      target.rank === card.rank + 1 && color(target.suit) !== color(card.suit);
-    return allowed;
+export type Action =
+  | {
+      type: 'MOVE';
+      from: { type: 'tableau'; index: number } | { type: 'waste' };
+      to:
+        | { type: 'tableau'; index: number }
+        | { type: 'foundation'; suit: Suit };
+    }
+  | { type: 'REDEPLOY_STOCK' }
+  | { type: 'FLIP_TABLEAU_TOP'; pileIndex: number }
+  | { type: 'UNDO' }
+  | { type: 'REDO' }
+  | { type: 'DRAW_STOCK' };
+
+export function validateAction(state: GameState, action: Action): boolean {
+  switch (action.type) {
+    case 'MOVE': {
+      if (action.from.type === 'tableau' && action.to.type === 'tableau') {
+        const fromPile = state.piles.tableau[action.from.index];
+        const toPile = state.piles.tableau[action.to.index];
+        if (!fromPile.length) return false;
+        const card = fromPile[fromPile.length - 1];
+        const target = toPile[toPile.length - 1];
+        if (!card.faceUp) return false;
+        if (!target) return card.rank === 13;
+        return (
+          target.rank === card.rank + 1 &&
+          color(target.suit) !== color(card.suit)
+        );
+      }
+      if (action.from.type === 'waste' && action.to.type === 'foundation') {
+        const card = state.piles.waste[state.piles.waste.length - 1];
+        const foundation = state.piles.foundations[action.to.suit];
+        return (
+          !!card &&
+          card.suit === action.to.suit &&
+          card.rank === foundation.length + 1
+        );
+      }
+      return false;
+    }
+    case 'REDEPLOY_STOCK':
+      return (
+        state.piles.stock.length === 0 &&
+        state.piles.waste.length > 0 &&
+        state.redealsUsed < state.maxRedeals
+      );
+    case 'FLIP_TABLEAU_TOP': {
+      const pile = state.piles.tableau[action.pileIndex];
+      const card = pile[pile.length - 1];
+      return !!card && !card.faceUp;
+    }
+    case 'UNDO':
+      return state.history.length > 0;
+    case 'REDO':
+      return state.future.length > 0;
+    case 'DRAW_STOCK':
+      return (
+        state.piles.stock.length > 0 ||
+        (state.piles.waste.length > 0 && state.redealsUsed < state.maxRedeals)
+      );
+    default:
+      return false;
   }
-  if (action.type === 'REDEPLOY_STOCK') {
-    return (
-      state.piles.stock.length === 0 &&
-      state.piles.waste.length > 0 &&
-      state.redealsUsed < state.maxRedeals
-    );
-  }
-  return true;
 }
 
 function checkWin(state: GameState) {
@@ -194,165 +187,43 @@ function checkWin(state: GameState) {
   }
 }
 
-export function applyAction(state: GameState, action: any): void {
-  if (action.type === 'UNDO') {
-    if (state.prev) {
-      state.next = clone(state);
-      Object.assign(state, state.prev);
-    }
-    return;
-  }
-  if (action.type === 'REDO') {
-    if (state.next) {
-      state.prev = clone(state);
-      Object.assign(state, state.next);
-    }
-    return;
-  }
-
-  state.prev = clone(state);
-  state.next = undefined;
-
-  if (action.type === 'MOVE') {
-    if (action.from.type === 'waste' && action.to.type === 'foundation') {
-      const card = state.piles.waste.pop();
-      if (card) {
-        state.piles.foundations[action.to.suit as Suit].push(card);
-        state.score += 10;
-      }
-    } else if (action.from.type === 'tableau' && action.to.type === 'tableau') {
-      const card = state.piles.tableau[action.from.index].pop();
-      if (card) state.piles.tableau[action.to.index].push(card);
-    }
-  } else if (action.type === 'FLIP_TABLEAU_TOP') {
-    const pile = state.piles.tableau[action.pileIndex];
-    const card = pile[pile.length - 1];
-    if (card && !card.faceUp) {
-      card.faceUp = true;
-      state.score += 5;
-    }
-  } else if (action.type === 'REDEPLOY_STOCK') {
-    state.piles.stock = state.piles.waste.reverse();
-    state.piles.waste = [];
-    state.redealsUsed += 1;
-  }
-
-  checkWin(state);
-}
-
-export function getHint(state: GameState) {
-  const wasteTop = state.piles.waste[state.piles.waste.length - 1];
-  if (wasteTop) {
-    const foundation = state.piles.foundations[wasteTop.suit];
-    const needed = foundation.length + 1;
-    if (wasteTop.rank === needed) {
-      return {
-        from: { type: 'waste' },
-        to: { type: 'foundation', suit: wasteTop.suit },
-      } as const;
-    }
-  }
-  return null;
-
-  const stock = deck.slice(index);
-  const waste: Card[] = [];
-  const foundations: Record<Suit, Card[]> = { C: [], D: [], H: [], S: [] };
-  return {
-    piles: { stock, waste, foundations, tableau },
-    drawMode: options.drawMode ?? 'draw-1',
-    maxRedeals: options.maxRedeals ?? Infinity,
-    redealsUsed: 0,
-    score: 0,
-    history: [],
-    future: [],
-    isWon: false,
-    slug: 'solitaire-klondike',
-  };
-}
-
-function color(suit: Suit): 'red' | 'black' {
-  return suit === 'C' || suit === 'S' ? 'black' : 'red';
-}
-
-export type Action =
-  | { type: 'MOVE'; from: any; to: any }
-  | { type: 'REDEPLOY_STOCK' }
-  | { type: 'FLIP_TABLEAU_TOP'; pileIndex: number }
-  | { type: 'UNDO' }
-  | { type: 'REDO' }
-  | { type: 'DRAW_STOCK' };
-
-export function validateAction(state: GameState, action: Action): boolean {
-  switch (action.type) {
-    case 'MOVE': {
-      const { from, to } = action;
-      if (from.type === 'tableau' && to.type === 'tableau') {
-        const src = state.piles.tableau[from.index];
-        const dst = state.piles.tableau[to.index];
-        const card = src[src.length - 1];
-        if (!card || !card.faceUp) return false;
-        const top = dst[dst.length - 1];
-        if (!top) return card.rank === 13; // king on empty
-        return (
-          color(card.suit) !== color(top.suit) && card.rank === top.rank - 1
-        );
-      } else if (from.type === 'waste' && to.type === 'foundation') {
-        const card = state.piles.waste[state.piles.waste.length - 1];
-        if (!card) return false;
-        if (card.suit !== to.suit) return false;
-        const foundation = state.piles.foundations[to.suit];
-        return card.rank === foundation.length + 1;
-      }
-      return false;
-    }
-    case 'REDEPLOY_STOCK':
-      return (
-        state.piles.stock.length === 0 &&
-        state.piles.waste.length > 0 &&
-        state.redealsUsed < state.maxRedeals
-      );
-    case 'FLIP_TABLEAU_TOP': {
-      const pile = state.piles.tableau[action.pileIndex];
-      if (!pile.length) return false;
-      const card = pile[pile.length - 1];
-      return !card.faceUp;
-    }
-    case 'UNDO':
-      return state.history.length > 0;
-    case 'REDO':
-      return state.future.length > 0;
-    case 'DRAW_STOCK':
-      return state.piles.stock.length > 0;
-    default:
-      return false;
-  }
-}
-
-function checkWin(state: GameState): void {
-  const f = state.piles.foundations;
-  state.isWon =
-    f.C.length === 13 &&
-    f.D.length === 13 &&
-    f.H.length === 13 &&
-    f.S.length === 13;
-}
-
 export function applyAction(state: GameState, action: Action): void {
-  if (action.type !== 'UNDO' && action.type !== 'REDO') {
-    state.history.push(cloneState(state));
-    state.future = [];
+  switch (action.type) {
+    case 'UNDO': {
+      const snap = state.history.pop();
+      if (snap) {
+        state.future.push(cloneState(state));
+        restoreState(state, snap);
+      }
+      return;
+    }
+    case 'REDO': {
+      const snap = state.future.pop();
+      if (snap) {
+        state.history.push(cloneState(state));
+        restoreState(state, snap);
+      }
+      return;
+    }
   }
+
+  state.history.push(cloneState(state));
+  state.future = [];
+
   switch (action.type) {
     case 'MOVE': {
-      const { from, to } = action;
-      if (from.type === 'tableau' && to.type === 'tableau') {
-        const card = state.piles.tableau[from.index].pop()!;
-        state.piles.tableau[to.index].push(card);
-      } else if (from.type === 'waste' && to.type === 'foundation') {
+      if (action.from.type === 'tableau' && action.to.type === 'tableau') {
+        const fromPile = state.piles.tableau[action.from.index];
+        const toPile = state.piles.tableau[action.to.index];
+        const card = fromPile.pop()!;
+        toPile.push(card);
+      } else if (
+        action.from.type === 'waste' &&
+        action.to.type === 'foundation'
+      ) {
         const card = state.piles.waste.pop()!;
-        state.piles.foundations[to.suit].push(card);
+        state.piles.foundations[action.to.suit].push(card);
         state.score += 10;
-        checkWin(state);
       }
       break;
     }
@@ -373,23 +244,15 @@ export function applyAction(state: GameState, action: Action): void {
       }
       break;
     }
-    case 'UNDO': {
-      const snap = state.history.pop();
-      if (snap) {
-        state.future.push(cloneState(state));
-        restoreState(state, snap);
-      }
-      break;
-    }
-    case 'REDO': {
-      const snap = state.future.pop();
-      if (snap) {
-        state.history.push(cloneState(state));
-        restoreState(state, snap);
-      }
-      break;
-    }
     case 'DRAW_STOCK': {
+      if (state.piles.stock.length === 0) {
+        state.piles.stock = state.piles.waste
+          .reverse()
+          .map((c) => ({ ...c, faceUp: false }));
+        state.piles.waste = [];
+        state.redealsUsed += 1;
+        break;
+      }
       const count = state.drawMode === 'draw-3' ? 3 : 1;
       for (let i = 0; i < count && state.piles.stock.length; i++) {
         const card = state.piles.stock.pop()!;
@@ -399,18 +262,26 @@ export function applyAction(state: GameState, action: Action): void {
       break;
     }
   }
+  checkWin(state);
 }
 
 export function getHint(state: GameState): { from: any; to: any } | undefined {
-  const wasteCard = state.piles.waste[state.piles.waste.length - 1];
-  if (wasteCard) {
-    const foundation = state.piles.foundations[wasteCard.suit];
-    if (wasteCard.rank === foundation.length + 1) {
+  const card = state.piles.waste[state.piles.waste.length - 1];
+  if (card) {
+    const foundation = state.piles.foundations[card.suit];
+    if (card.rank === foundation.length + 1) {
       return {
         from: { type: 'waste' },
-        to: { type: 'foundation', suit: wasteCard.suit },
+        to: { type: 'foundation', suit: card.suit },
       };
     }
   }
   return undefined;
+}
+
+export function getNextActions(state: GameState): Action[] {
+  const actions: Action[] = [];
+  if (validateAction(state, { type: 'DRAW_STOCK' }))
+    actions.push({ type: 'DRAW_STOCK' });
+  return actions;
 }

--- a/src/games/war/index.ts
+++ b/src/games/war/index.ts
@@ -1,5 +1,11 @@
 import { registerGame } from '../../gameAPI';
-import { createInitialState, applyAction, getPlayerView } from './rules';
+import {
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions,
+  validateAction,
+} from './rules';
 
 registerGame({
   slug: 'war',
@@ -7,10 +13,15 @@ registerGame({
   createInitialState,
   applyAction,
   getPlayerView,
-  getNextActions: () => ['draw'],
+  getNextActions,
   rules: {
-    validate: (_state, action) => action === 'draw',
+    validate: validateAction,
   },
 });
-
-export { createInitialState, applyAction, getPlayerView };
+export {
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions,
+  validateAction,
+};

--- a/src/games/war/rules.ts
+++ b/src/games/war/rules.ts
@@ -1,5 +1,4 @@
 export type Rank =
-
   | '2'
   | '3'
   | '4'
@@ -13,27 +12,8 @@ export type Rank =
   | 'Q'
   | 'K'
   | 'A';
-export interface Card {
-  rank: Rank;
-  suit: string;
-}
-export interface GameState {
-  deck: Card[];
-
-  | 'A'
-  | 'K'
-  | 'Q'
-  | 'J'
-  | '10'
-  | '9'
-  | '8'
-  | '7'
-  | '6'
-  | '5'
-  | '4'
-  | '3'
-  | '2';
 export type Suit = 'C' | 'D' | 'H' | 'S';
+
 export interface Card {
   rank: Rank;
   suit: Suit;
@@ -41,9 +21,7 @@ export interface Card {
 
 export interface GameState {
   deck: Card[];
-  warPile?: Card[];
   lastDraw?: { p1: Card; p2: Card };
-
   winner?: 'p1' | 'p2' | 'war';
 }
 
@@ -63,43 +41,15 @@ const rankOrder: Rank[] = [
   'A',
 ];
 
-
-export function createInitialState(): GameState {
-  const suits = ['S', 'H', 'D', 'C'];
-  const deck: Card[] = [];
-  for (const r of rankOrder) {
-    for (const s of suits) deck.push({ rank: r, suit: s });
-  }
-  return { deck };
-}
-
-export function applyAction(state: GameState, action: 'draw') {
-  if (action !== 'draw' || state.deck.length < 2) return;
-  const p1 = state.deck.pop()!;
-  const p2 = state.deck.pop()!;
-  const diff = rankOrder.indexOf(p1.rank) - rankOrder.indexOf(p2.rank);
-  if (diff > 0) state.winner = 'p1';
-  else if (diff < 0) state.winner = 'p2';
-  else state.winner = 'war';
-}
-
-export function getPlayerView(state: GameState, _player: 'p1' | 'p2') {
-  return {
-    ...state,
-    deck: undefined,
-    deckCount: state.deck.length,
-  } as Partial<GameState> & { deckCount: number };
-
-export function createDeck(): Card[] {
+function createDeck(): Card[] {
   const suits: Suit[] = ['C', 'D', 'H', 'S'];
   const deck: Card[] = [];
-  for (const suit of suits) {
-    for (const rank of rankOrder) deck.push({ rank, suit });
-  }
+  for (const r of rankOrder)
+    for (const s of suits) deck.push({ rank: r, suit: s });
   return deck;
 }
 
-export function shuffle<T>(arr: T[]): T[] {
+function shuffle<T>(arr: T[]): T[] {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [arr[i], arr[j]] = [arr[j], arr[i]];
@@ -111,43 +61,14 @@ export function createInitialState(): GameState {
   return { deck: shuffle(createDeck()) };
 }
 
+export type Action = 'draw';
+
 function value(rank: Rank): number {
   return rankOrder.indexOf(rank);
 }
 
-export function applyAction(state: GameState, action: 'draw'): void {
-  if (action !== 'draw') return;
-  if (state.winner === 'war') {
-    // Resolve ongoing war
-    // burn 3 cards each if possible
-    const warPile = state.warPile ?? [];
-    const burnCount = Math.min(3, Math.floor(state.deck.length / 2));
-    for (let i = 0; i < burnCount; i++) {
-      warPile.push(state.deck.pop()!); // p1 burn
-      warPile.push(state.deck.pop()!); // p2 burn
-    }
-    if (state.deck.length < 2) {
-      state.warPile = warPile;
-      return;
-    }
-    const p1 = state.deck.pop()!;
-    const p2 = state.deck.pop()!;
-    warPile.push(p1, p2);
-    state.lastDraw = { p1, p2 };
-    const v1 = value(p1.rank);
-    const v2 = value(p2.rank);
-    if (v1 > v2) state.winner = 'p1';
-    else if (v2 > v1) state.winner = 'p2';
-    else {
-      state.winner = 'war';
-      state.warPile = warPile;
-    }
-    if (state.winner !== 'war') {
-      state.warPile = undefined;
-    }
-    return;
-  }
-  if (state.deck.length < 2) return;
+export function applyAction(state: GameState, action: Action): void {
+  if (action !== 'draw' || state.deck.length < 2) return;
   const p1 = state.deck.pop()!;
   const p2 = state.deck.pop()!;
   state.lastDraw = { p1, p2 };
@@ -155,10 +76,7 @@ export function applyAction(state: GameState, action: 'draw'): void {
   const v2 = value(p2.rank);
   if (v1 > v2) state.winner = 'p1';
   else if (v2 > v1) state.winner = 'p2';
-  else {
-    state.winner = 'war';
-    state.warPile = [p1, p2];
-  }
+  else state.winner = 'war';
 }
 
 export function getPlayerView(
@@ -167,4 +85,12 @@ export function getPlayerView(
 ): Omit<GameState, 'deck'> & { deckCount: number } {
   const { deck, ...rest } = state;
   return { ...rest, deckCount: deck.length };
+}
+
+export function getNextActions(state: GameState): Action[] {
+  return state.deck.length >= 2 ? ['draw'] : [];
+}
+
+export function validateAction(state: GameState, action: Action): boolean {
+  return action === 'draw' && state.deck.length >= 2;
 }


### PR DESCRIPTION
## Summary
- Clean game registry API and animation helpers
- Add dynamic HostPanel and form hook for table creation
- Implement and register simplified Blackjack, Solitaire, and War engines

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689d7c6e4db0832fb976d7bc067a703f