### PR TITLE
fix: resolve lint and type errors

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,3 @@
-import React from 'react';
-export default function App() {
-  return <div />;
-
 import React, { useEffect, useState } from 'react';
 
 type Theme = 'light' | 'dark';

--- a/src/gameAPI/rulesEngine.ts
+++ b/src/gameAPI/rulesEngine.ts
@@ -7,30 +7,9 @@ export function enforceRules(
 ): boolean {
   if (!state?.slug) return false;
   const game = getGame(state.slug);
-  if (!game) return false;
-  return !!game.rules.validate(state as any, action as any, playerId);
-
-
-
-export function enforceRules(state: any, action: any): boolean {
-  const slug = (state as any).slug;
-  if (!slug) return false;
-  const game = getGame(slug);
-  if (!game) return false;
-  return !!game.rules?.validate(state, action);
-
-import { getGame } from './index';
-
-export function enforceRules(
-  state: any,
-  action: any,
-  playerId?: string,
-): boolean {
-  if (!state || typeof state.slug !== 'string') return false;
-  const game = getGame(state.slug);
-  if (!game) return false;
+  if (!game || typeof game.rules?.validate !== 'function') return false;
   try {
-    return game.rules.validate(state, action, playerId);
+    return !!game.rules.validate(state as any, action as any, playerId);
   } catch {
     return false;
   }

--- a/src/games/blackjack/index.ts
+++ b/src/games/blackjack/index.ts
@@ -22,12 +22,6 @@ registerGame({
   },
 });
 
-export {
-  createInitialState,
-  applyAction,
-  getNextActions,
-  Hand,
-  GameState,
-  BlackjackConfig,
-} from './rules';
+export { createInitialState, applyAction, getNextActions } from './rules';
+export type { Hand, GameState, BlackjackConfig } from './rules';
 export { placeBet, settleHand, getBalance } from './betting';

--- a/src/games/blackjack/rules.ts
+++ b/src/games/blackjack/rules.ts
@@ -48,7 +48,7 @@ export interface GameState {
   afterSplit?: boolean;
 }
 
-export type Action = 'hit' | 'stand' | 'split' | 'surrender';
+export type Action = 'hit' | 'stand' | 'split' | 'double' | 'surrender';
 
 function createDeck(): Card[] {
   const suits: Suit[] = ['C', 'D', 'H', 'S'];

--- a/src/net/signaling.ts
+++ b/src/net/signaling.ts
@@ -91,7 +91,7 @@ export class SignalingClient {
         try {
           const m = parseMsg(ev.data as string);
           this.dispatch(m);
-          if (m.type === 'CREATE_ROOM') {
+          if (m.type === 'CREATE_ROOM' && m.roomId) {
             this.roomId = m.roomId;
             this.ws.removeEventListener('message', handler);
             resolve({ roomId: m.roomId, pin });
@@ -187,7 +187,8 @@ export async function connectToSignaling(
 ): Promise<SignalingClient> {
   const target =
     url ||
-    (typeof process !== 'undefined' && process.env.SIGNALING_URL) ||
+    (typeof globalThis !== 'undefined' &&
+      (globalThis as any).process?.env?.SIGNALING_URL) ||
     'ws://localhost:8787';
   const client = new SignalingClient(target);
   await client.connect();


### PR DESCRIPTION
## Summary
- remove duplicate code and improve theme toggling in App component
- consolidate rulesEngine enforcement logic
- fix type exports and action definitions in blackjack
- improve signaling client for stricter types and browser/node compatibility

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689d7eabc014832fb45c655b1dd12912