### PR TITLE
refactor: centralize deck utilities

### DIFF
--- a/src/games/blackjack/rules.ts
+++ b/src/games/blackjack/rules.ts
@@ -12,7 +12,9 @@ export type Rank =
   | 'J'
   | 'Q'
   | 'K';
-export type Suit = 'C' | 'D' | 'H' | 'S';
+import { buildDeck, SUITS } from '../../util/cards';
+
+export type Suit = (typeof SUITS)[number];
 
 export interface Card {
   rank: Rank;
@@ -50,26 +52,24 @@ export interface GameState {
 
 export type Action = 'hit' | 'stand' | 'split' | 'surrender';
 
+const ranks: Rank[] = [
+  'A',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  'J',
+  'Q',
+  'K',
+];
+
 function createDeck(): Card[] {
-  const suits: Suit[] = ['C', 'D', 'H', 'S'];
-  const ranks: Rank[] = [
-    'A',
-    '2',
-    '3',
-    '4',
-    '5',
-    '6',
-    '7',
-    '8',
-    '9',
-    '10',
-    'J',
-    'Q',
-    'K',
-  ];
-  const deck: Card[] = [];
-  for (const r of ranks) for (const s of suits) deck.push({ rank: r, suit: s });
-  return deck;
+  return buildDeck(ranks, (rank, suit) => ({ rank, suit }));
 }
 
 export function createInitialState(config: BlackjackConfig): GameState {

--- a/src/games/poker-holdem/index.ts
+++ b/src/games/poker-holdem/index.ts
@@ -1,7 +1,9 @@
 import { registerGame } from '../../gameAPI';
 import { createMoneyPool, type MoneyPool } from '../../store/moneyPool';
+import { buildDeck, shuffle, SUITS } from '../../util/cards';
+import { rngFromString } from '../../util/random';
 
-export type Suit = 'S' | 'H' | 'D' | 'C';
+export type Suit = (typeof SUITS)[number];
 export type Rank =
   | '2'
   | '3'
@@ -48,46 +50,24 @@ export type Action =
   | { type: 'check'; playerId: string }
   | { type: 'fold'; playerId: string };
 
+const ranks: Rank[] = [
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'T',
+  'J',
+  'Q',
+  'K',
+  'A',
+];
+
 function createDeck(): Card[] {
-  const suits: Suit[] = ['S', 'H', 'D', 'C'];
-  const ranks: Rank[] = [
-    '2',
-    '3',
-    '4',
-    '5',
-    '6',
-    '7',
-    '8',
-    '9',
-    'T',
-    'J',
-    'Q',
-    'K',
-    'A',
-  ];
-  const deck: Card[] = [];
-  for (const r of ranks) for (const s of suits) deck.push(`${r}${s}` as Card);
-  return deck;
-}
-
-function rngFromSeed(seed: string) {
-  let h = 0;
-  for (let i = 0; i < seed.length; i++)
-    h = Math.imul(31, h) + seed.charCodeAt(i);
-  return function () {
-    h |= 0;
-    h = (h + 0x6d2b79f5) | 0;
-    let t = Math.imul(h ^ (h >>> 15), 1 | h);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function shuffle<T>(arr: T[], rnd: () => number) {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rnd() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
+  return buildDeck(ranks, (r, s) => `${r}${s}` as Card);
 }
 
 function draw(state: GameState): Card {
@@ -366,7 +346,7 @@ function createInitialState(
   seed = Date.now().toString(),
   playerIds: string[] = ['p1', 'p2'],
 ): GameState {
-  const rnd = rngFromSeed(seed);
+  const rnd = rngFromString(seed);
   const deck = createDeck();
   shuffle(deck, rnd);
   const pool = createMoneyPool();

--- a/src/games/sueca/rules.ts
+++ b/src/games/sueca/rules.ts
@@ -1,4 +1,6 @@
-export type Suit = 'C' | 'D' | 'H' | 'S';
+import { buildDeck, SUITS } from '../../util/cards';
+
+export type Suit = (typeof SUITS)[number];
 export type Rank = 'A' | '7' | 'K' | 'J' | 'Q' | '6' | '5' | '4' | '3' | '2';
 export interface Card {
   suit: Suit;
@@ -19,16 +21,8 @@ const POINTS: Record<Rank, number> = {
   '2': 0,
 };
 
-export const createDeck = (): Card[] => {
-  const suits: Suit[] = ['C', 'D', 'H', 'S'];
-  const deck: Card[] = [];
-  for (const suit of suits) {
-    for (const rank of ORDER) {
-      deck.push({ suit, rank });
-    }
-  }
-  return deck;
-};
+export const createDeck = (): Card[] =>
+  buildDeck(ORDER, (rank, suit) => ({ suit, rank }));
 
 export interface DealResult {
   hands: Card[][];

--- a/src/games/war/rules.ts
+++ b/src/games/war/rules.ts
@@ -12,7 +12,9 @@ export type Rank =
   | 'Q'
   | 'K'
   | 'A';
-export type Suit = 'C' | 'D' | 'H' | 'S';
+import { SUITS, buildDeck, shuffle } from '../../util/cards';
+
+export type Suit = (typeof SUITS)[number];
 
 export interface Card {
   rank: Rank;
@@ -42,19 +44,7 @@ const rankOrder: Rank[] = [
 ];
 
 function createDeck(): Card[] {
-  const suits: Suit[] = ['C', 'D', 'H', 'S'];
-  const deck: Card[] = [];
-  for (const r of rankOrder)
-    for (const s of suits) deck.push({ rank: r, suit: s });
-  return deck;
-}
-
-function shuffle<T>(arr: T[]): T[] {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr;
+  return buildDeck(rankOrder, (rank, suit) => ({ rank, suit }));
 }
 
 export function createInitialState(): GameState {

--- a/src/util/cards.ts
+++ b/src/util/cards.ts
@@ -1,0 +1,23 @@
+export const SUITS = ['C', 'D', 'H', 'S'] as const;
+export type Suit = (typeof SUITS)[number];
+
+export function buildDeck<R, C>(
+  ranks: readonly R[],
+  factory: (rank: R, suit: Suit) => C,
+): C[] {
+  const deck: C[] = [];
+  for (const suit of SUITS) {
+    for (const rank of ranks) {
+      deck.push(factory(rank, suit));
+    }
+  }
+  return deck;
+}
+
+export function shuffle<T>(arr: T[], rnd: () => number = Math.random): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rnd() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}

--- a/src/util/random.ts
+++ b/src/util/random.ts
@@ -1,0 +1,17 @@
+export function mulberry32(seed: number): () => number {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function rngFromString(seed: string): () => number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(31, h) + seed.charCodeAt(i);
+  }
+  return mulberry32(h);
+}


### PR DESCRIPTION
## Summary
- add shared card utilities for deck creation and shuffling
- unify seeded RNG logic across games
- simplify game rule files to use new helpers

## Testing
- `pnpm test` *(fails: Transform failed with 1 error: Unexpected "export" in src/gameAPI/rulesEngine.ts)*
- `pnpm lint` *(fails: Parsing error in src/gameAPI/rulesEngine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d7eb46f8c832fb545e3b276f2954d