### PR TITLE
feat: improve blackjack game registration

### DIFF
--- a/src/games/blackjack/index.ts
+++ b/src/games/blackjack/index.ts
@@ -2,26 +2,29 @@ import { registerGame } from '../../gameAPI';
 import {
   createInitialState,
   applyAction,
+  getPlayerView,
   getNextActions,
-  Hand,
-  GameState,
-  BlackjackConfig,
+  validateAction,
 } from './rules';
 
 registerGame({
   slug: 'blackjack',
   meta: { name: 'Blackjack' },
-  createInitialState: (config: BlackjackConfig) => createInitialState(config),
-  applyAction: (state, action) =>
-    applyAction(state as GameState, action as any),
-  getPlayerView: (state) => state,
-  getNextActions: (state) => getNextActions(state as GameState, ''),
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions,
   rules: {
-    validate: (state, action) =>
-      getNextActions(state as GameState, '').includes(action as any),
+    validate: validateAction,
   },
 });
 
-export { createInitialState, applyAction, getNextActions } from './rules';
+export {
+  createInitialState,
+  applyAction,
+  getPlayerView,
+  getNextActions,
+  validateAction,
+} from './rules';
 export type { Hand, GameState, BlackjackConfig } from './rules';
 export { placeBet, settleHand, getBalance } from './betting';

--- a/src/games/blackjack/rules.ts
+++ b/src/games/blackjack/rules.ts
@@ -127,6 +127,14 @@ function checkPenetration(state: GameState) {
   }
 }
 
+export function getPlayerView(
+  state: GameState,
+  _playerId: string,
+): Omit<GameState, 'shoe'> & { shoeCount: number } {
+  const { shoe, ...rest } = state;
+  return { ...rest, shoeCount: shoe.length };
+}
+
 export function getNextActions(state: GameState, _playerId: string): Action[] {
   if (state.stage !== 'player') return [];
   const hand = state.hands[state.active];
@@ -155,6 +163,14 @@ export function getNextActions(state: GameState, _playerId: string): Action[] {
     }
   }
   return actions;
+}
+
+export function validateAction(
+  state: GameState,
+  action: Action,
+  playerId?: string,
+): boolean {
+  return getNextActions(state, playerId ?? '').includes(action);
 }
 
 function settle(state: GameState) {


### PR DESCRIPTION
## Summary
- add getPlayerView and validateAction helpers for Blackjack
- register Blackjack game with new helpers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d81467c60832f9e25a4d868fd618f