### PR TITLE
feat(war): resolve basic war scenario in rules

### DIFF
--- a/src/games/war/index.ts
+++ b/src/games/war/index.ts
@@ -25,3 +25,4 @@ export {
   getNextActions,
   validateAction,
 };
+export type { Card, GameState } from './rules';

--- a/src/games/war/rules.ts
+++ b/src/games/war/rules.ts
@@ -59,11 +59,26 @@ function value(rank: Rank): number {
 
 export function applyAction(state: GameState, action: Action): void {
   if (action !== 'draw' || state.deck.length < 2) return;
+  // draw the initial face-up cards
   const p1 = state.deck.pop()!;
   const p2 = state.deck.pop()!;
   state.lastDraw = { p1, p2 };
-  const v1 = value(p1.rank);
-  const v2 = value(p2.rank);
+  let v1 = value(p1.rank);
+  let v2 = value(p2.rank);
+
+  // if the ranks tie and there are enough cards, resolve a simple "war"
+  if (v1 === v2 && state.deck.length >= 4) {
+    // burn one card for each player
+    state.deck.pop();
+    state.deck.pop();
+    // draw new face-up cards for comparison
+    const war1 = state.deck.pop()!;
+    const war2 = state.deck.pop()!;
+    state.lastDraw = { p1: war1, p2: war2 };
+    v1 = value(war1.rank);
+    v2 = value(war2.rank);
+  }
+
   if (v1 > v2) state.winner = 'p1';
   else if (v2 > v1) state.winner = 'p2';
   else state.winner = 'war';

--- a/tests/games/war/rules.test.ts
+++ b/tests/games/war/rules.test.ts
@@ -5,7 +5,7 @@ import {
   getPlayerView,
   type GameState,
   type Card,
-} from 'src/games/war/rules';
+} from 'src/games/war';
 
 const card = (rank: Card['rank']): Card => ({ rank, suit: 'S' });
 
@@ -26,6 +26,23 @@ describe('war logic', () => {
     const state: GameState = { deck: [card('7'), card('7')] };
     applyAction(state, 'draw');
     expect(state.winner).toBe('war');
+  });
+
+  it('resolves a basic war when enough cards remain', () => {
+    // Deck order is bottom -> top. Popped in reverse when drawing.
+    const state: GameState = {
+      deck: [
+        card('5'), // p2 war card
+        card('K'), // p1 war card
+        card('4'), // burn for p2
+        card('3'), // burn for p1
+        card('7'), // p2 initial
+        card('7'), // p1 initial
+      ],
+    };
+    applyAction(state, 'draw');
+    expect(state.winner).toBe('p1');
+    expect(state.lastDraw).toEqual({ p1: card('K'), p2: card('5') });
   });
 });
 


### PR DESCRIPTION
## Summary
- handle basic war resolution by burning and drawing extra cards
- export war types and adjust tests to cover war showdown

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d871a9f30832f88157964d521df46