### PR TITLE
feat: add basic routing and theme provider

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,65 +1,66 @@
-import React, { useEffect, useState } from 'react';
-import { ToastProvider, useToast } from './Toaster';
-
-type Theme = 'light' | 'dark';
-
-function applyTheme(theme: Theme) {
-  document.body.classList.remove('light', 'dark');
-  document.body.classList.add(theme);
-}
-
-function AppContent() {
-  const [theme, setTheme] = useState<Theme>('dark');
-  const toast = useToast();
-
-  useEffect(() => {
-    const stored = localStorage.getItem('theme') as Theme | null;
-    if (stored === 'light' || stored === 'dark') {
-      setTheme(stored);
-      applyTheme(stored);
-    } else {
-      const prefersDark = window.matchMedia
-        ? window.matchMedia('(prefers-color-scheme: dark)').matches
-        : false;
-      const initial: Theme = prefersDark ? 'dark' : 'light';
-      setTheme(initial);
-      applyTheme(initial);
-    }
-  }, []);
-
-  const toggleTheme = () => {
-    const next: Theme = theme === 'dark' ? 'light' : 'dark';
-    setTheme(next);
-    applyTheme(next);
-    localStorage.setItem('theme', next);
-    toast(`Switched to ${next} mode`, 'success');
-  };
-
-  return (
-    <div>
-      <header>
-        <button
-          className="theme-toggle"
-          onClick={toggleTheme}
-          aria-label="Toggle color theme"
-          aria-pressed={theme === 'dark'}
-        >
-          {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
-        </button>
-      </header>
-      <main role="main">
-        <h1>Deck Arcade</h1>
-        <p>The current theme is {theme} mode.</p>
-        <div className="table" role="img" aria-label="Table preview" />
-      </main>
-    </div>
-  );
-}
+import React from 'react';
+import '../styles/global.css';
+import { ThemeProvider } from './ThemeProvider';
+import { Header } from './Header';
+import { Router } from './router';
+import { Home } from './Home';
+import { Games } from './Games';
+import { Host } from './Host';
 
 export default function App() {
+  const routes = [
+    {
+      path: '/',
+      element: (
+        <>
+          <Header />
+          <Home />
+        </>
+      ),
+    },
+    {
+      path: '/games',
+      element: (
+        <>
+          <Header />
+          <Games />
+        </>
+      ),
+    },
+    {
+      path: '/quick',
+      element: (
+        <>
+          <Header />
+          <Games />
+        </>
+      ),
+    },
+    {
+      path: '/host',
+      element: (
+        <>
+          <Header />
+          <Host />
+        </>
+      ),
+    },
+    {
+      path: '/how',
+      element: (
+        <>
+          <Header />
+          <div className="container">
+            <h2>How It Works</h2>
+            <p>Join by PIN or host locally with WebRTC.</p>
+          </div>
+        </>
+      ),
+    },
+  ];
   return (
-    <ToastProvider>
-      <AppContent />
-    </ToastProvider>
+    <ThemeProvider>
+      <Router routes={routes} />
+    </ThemeProvider>
   );
 }

--- a/src/app/Games.tsx
+++ b/src/app/Games.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function Games() {
+  const games = ['blackjack', 'poker-holdem', 'solitaire', 'sueca', 'war'];
+  return (
+    <div className="container">
+      <h2>Games</h2>
+      <ul>
+        {games.map((g) => (
+          <li key={g}>{g}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { navigate } from './router';
+
+export function Header() {
+  return (
+    <header>
+      <nav>
+        <a
+          href="/"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/');
+          }}
+        >
+          Home
+        </a>
+        <a
+          href="/games"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/games');
+          }}
+        >
+          Games
+        </a>
+        <a
+          href="/host"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/host');
+          }}
+        >
+          Host
+        </a>
+        <a
+          href="/how"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/how');
+          }}
+        >
+          How
+        </a>
+      </nav>
+    </header>
+  );
+}

--- a/src/app/Home.tsx
+++ b/src/app/Home.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useTheme } from './ThemeProvider';
+
+export function Home() {
+  const { theme, toggle } = useTheme();
+  return (
+    <div className="container">
+      <h2>Deck Arcade</h2>
+      <p>The current theme is {theme} mode.</p>
+      <button className="theme-toggle" onClick={toggle}>
+        {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+      </button>
+    </div>
+  );
+}

--- a/src/app/Host.tsx
+++ b/src/app/Host.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function Host() {
+  return (
+    <div className="container">
+      <h2>Host a Game</h2>
+      <p>Hosting interface coming soon.</p>
+    </div>
+  );
+}

--- a/src/app/ThemeProvider.tsx
+++ b/src/app/ThemeProvider.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggle: () => {},
+});
+
+function applyTheme(theme: Theme) {
+  document.body.classList.remove('light', 'dark');
+  document.body.classList.add(theme);
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const prefersDark = window.matchMedia
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : false;
+    const initial: Theme = stored ?? (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    applyTheme(initial);
+  }, []);
+
+  const toggle = () => {
+    const next: Theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    applyTheme(next);
+    localStorage.setItem('theme', next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+interface Route {
+  path: string;
+  element: React.ReactNode;
+}
+
+export function navigate(path: string) {
+  window.history.pushState({}, '', path);
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function Router({ routes }: { routes: Route[] }) {
+  const [path, setPath] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const onPopState = () => setPath(window.location.pathname);
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const route = routes.find((r) => r.path === path) ?? routes[0];
+  return <>{route.element}</>;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,16 @@
+@import '../theme.css';
+
+header {
+  padding: 1rem;
+  background: var(--background-color);
+}
+
+header nav a {
+  margin-right: 1rem;
+  color: var(--text-color);
+  text-decoration: none;
+}
+
+.container {
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- add simple ThemeProvider to manage dark and light modes
- implement lightweight router and navigation header
- scaffold pages for home, games, and host plus global styles

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8acc6d00832faf5673f4adf17322