### PR TITLE
Add host lobby modal and shared UI components

### DIFF
--- a/src/app/Host.tsx
+++ b/src/app/Host.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Modal } from '../ui/Modal';
+import { Button } from '../ui/Button';
+
+export const Host: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <main className="container" style={{ display: 'grid', gap: '1rem' }}>
+      <div className="card" style={{ padding: '1rem' }}>
+        <h2>Host a Table</h2>
+        <p>Spin up a lobby, set rules, share a PIN.</p>
+        <Button variant="primary" onClick={() => setOpen(true)}>
+          Create Lobby
+        </Button>
+      </div>
+      <Modal open={open} onClose={() => setOpen(false)} title="New Lobby">
+        <label>
+          Lobby Name
+          <br />
+          <input placeholder="e.g., Friday Night" />
+        </label>
+        <div style={{ marginTop: '.75rem', display: 'flex', gap: '.5rem' }}>
+          <Button variant="primary" onClick={() => setOpen(false)}>
+            Start
+          </Button>
+          <Button onClick={() => setOpen(false)}>Cancel</Button>
+        </div>
+      </Modal>
+    </main>
+  );
+};

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary';
+}
+
+export function Button({ variant, style, ...props }: ButtonProps) {
+  const baseStyle: React.CSSProperties = {
+    padding: '0.5rem 1rem',
+    borderRadius: 4,
+    cursor: 'pointer',
+  };
+  const variantStyle: React.CSSProperties =
+    variant === 'primary'
+      ? {
+          backgroundColor: 'var(--accent-color)',
+          color: '#fff',
+          border: 'none',
+        }
+      : {
+          backgroundColor: 'transparent',
+          border: '1px solid var(--text-color)',
+          color: 'var(--text-color)',
+        };
+  return (
+    <button
+      {...props}
+      style={{ ...baseStyle, ...variantStyle, ...(style ?? {}) }}
+    />
+  );
+}

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}
+
+export function Modal({ open, onClose, title, children }: ModalProps) {
+  if (!open) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--background-color)',
+          padding: '1rem',
+          borderRadius: 4,
+          minWidth: '300px',
+        }}
+      >
+        <h3>{title}</h3>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/tests/Host.test.tsx
+++ b/tests/Host.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { Host } from 'src/app/Host';
+
+describe('Host', () => {
+  it('opens and closes the lobby modal', () => {
+    render(<Host />);
+    fireEvent.click(screen.getByText('Create Lobby'));
+    expect(screen.queryByLabelText('Lobby Name')).not.toBeNull();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByLabelText('Lobby Name')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Introduce `Host` page with lobby creation modal
- Add reusable `Button` and `Modal` UI components
- Test modal open/close behavior for Host

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d8aee21e4832f82fc7d15fd4d2a37