### PR TITLE
feat: list games and add blackjack ui

### DIFF
--- a/src/app/Games.tsx
+++ b/src/app/Games.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { gameAPI } from '../gameAPI';
+
+// Import game modules so they register themselves
+import '../games/blackjack';
+import '../games/solitaire';
+import '../games/war';
+import '../games/poker-holdem';
+
+// Import UIs
+import { BlackjackUI } from '../games/blackjack/ui';
+import SolitaireUI from '../games/solitaire/ui';
+import WarUI from '../games/war/ui';
+
+const uiMap: Record<string, React.FC> = {
+  blackjack: BlackjackUI,
+  'solitaire-klondike': SolitaireUI,
+  war: WarUI,
+};
+
+export const Games: React.FC = () => {
+  const list = gameAPI.listGames();
+  return (
+    <main className="container" style={{ display: 'grid', gap: '1rem' }}>
+      <h2>Games</h2>
+      <div style={{ display: 'grid', gap: '1rem' }}>
+        {list.map((g) => {
+          const UI = uiMap[g.slug];
+          return (
+            <div key={g.slug} className="card" style={{ padding: '1rem' }}>
+              <h3 style={{ marginTop: 0 }}>{g.meta.name || g.slug}</h3>
+              {UI ? <UI /> : <p>Coming soon</p>}
+            </div>
+          );
+        })}
+      </div>
+    </main>
+  );
+};

--- a/src/gameAPI/index.ts
+++ b/src/gameAPI/index.ts
@@ -24,4 +24,14 @@ export function getGame(slug: string): GameRegistration | undefined {
   return registry.get(slug);
 }
 
+export function listGames(): GameRegistration[] {
+  return Array.from(registry.values());
+}
+
+export const gameAPI = {
+  registerGame,
+  getGame,
+  listGames,
+};
+
 export type Game = GameRegistration;

--- a/src/games/blackjack/ui.tsx
+++ b/src/games/blackjack/ui.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  createInitialState,
+  applyAction,
+  getNextActions,
+  type BlackjackConfig,
+} from './rules';
+
+const defaultConfig: BlackjackConfig = {
+  h17: false,
+  das: false,
+  resplitAces: false,
+  surrender: 'none',
+  payout: '3:2',
+  penetration: 1,
+};
+
+export function BlackjackUI() {
+  const [state, setState] = React.useState(() =>
+    createInitialState(defaultConfig),
+  );
+  const actions = getNextActions(state, 'player');
+
+  const doAction = (action: any) => {
+    applyAction(state, action);
+    setState({ ...state });
+  };
+
+  return (
+    <div>
+      <div>Dealer: {state.dealer.map((c) => c.rank).join(' ')}</div>
+      <div>Player: {state.hands[0].cards.map((c) => c.rank).join(' ')}</div>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        {actions.includes('hit') && (
+          <button onClick={() => doAction('hit')}>Hit</button>
+        )}
+        {actions.includes('stand') && (
+          <button onClick={() => doAction('stand')}>Stand</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BlackjackUI;


### PR DESCRIPTION
## Summary
- expose gameAPI.listGames and centralized gameAPI object
- add simple Blackjack UI component
- show all registered games in a new Games page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8b12cd04832f88c574f80463664a