### PR TITLE
feat: add navigation header component

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ToastProvider, useToast } from './Toaster';
+import { Header } from './Header';
 
 type Theme = 'light' | 'dark';
 
@@ -37,7 +38,7 @@ function AppContent() {
 
   return (
     <div>
-      <header>
+      <Header>
         <button
           className="theme-toggle"
           onClick={toggleTheme}
@@ -46,7 +47,7 @@ function AppContent() {
         >
           {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>
-      </header>
+      </Header>
       <main role="main">
         <h1>Deck Arcade</h1>
         <p>The current theme is {theme} mode.</p>

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from './router';
+
+interface HeaderProps {
+  children?: React.ReactNode;
+}
+
+export const Header: React.FC<HeaderProps> = ({ children }) => (
+  <header
+    className="container"
+    style={{
+      padding: '1rem 0',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '1rem',
+    }}
+  >
+    <div
+      style={{
+        fontFamily: 'var(--font-display)',
+        fontWeight: 800,
+        fontSize: '1.25rem',
+      }}
+    >
+      DeckArcade
+    </div>
+    <nav style={{ marginLeft: 'auto', display: 'flex', gap: '.75rem' }}>
+      <Link href="/">Home</Link>
+      <Link href="/games">Games</Link>
+      <Link href="/quick">Quick Play</Link>
+      <Link href="/host">Host</Link>
+      <Link href="/how">How It Works</Link>
+    </nav>
+    {children}
+  </header>
+);

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string;
+}
+
+export const Link: React.FC<LinkProps> = ({ href, children, ...props }) => (
+  <a href={href} {...props}>
+    {children}
+  </a>
+);


### PR DESCRIPTION
## Summary
- add navigation Header component with links
- integrate Header into App with theme toggle
- add simple Link router stub

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8b2c3d50832f921a09cca781d269