### PR TITLE
feat: add front-end game registry

### DIFF
--- a/src/gameAPI/index.ts
+++ b/src/gameAPI/index.ts
@@ -1,3 +1,6 @@
+import type { JSX } from 'react';
+
+// Existing game registration used by rules engine and tests
 export interface GameRegistration<
   State = any,
   Action = any,
@@ -14,14 +17,53 @@ export interface GameRegistration<
   };
 }
 
-const registry = new Map<string, GameRegistration>();
+// Registry backing the rules engine. Kept for backward compatibility with
+// existing tests and modules that rely on slug-based lookups.
+const rulesRegistry = new Map<string, GameRegistration>();
 
 export function registerGame(game: GameRegistration): void {
-  registry.set(game.slug, game);
+  rulesRegistry.set(game.slug, game);
 }
 
 export function getGame(slug: string): GameRegistration | undefined {
-  return registry.get(slug);
+  return rulesRegistry.get(slug);
 }
 
 export type Game = GameRegistration;
+
+// ---------------------------------------------------------------------------
+// Minimal front-end game contract and registry. Games may opt in to this API
+// to describe their UI and lobby characteristics without pulling in rules
+// logic. This mirrors the snippet provided in the task instructions.
+
+export type GameId = string;
+
+export type FrontAPI = {
+  animations: typeof import('./animations');
+  send: (event: string, payload?: any) => void; // to engine / network
+  requestState: () => any; // pull latest game state
+};
+
+export type GameMeta = {
+  id: GameId;
+  name: string;
+  minPlayers: number;
+  maxPlayers: number;
+  icon?: string;
+  createUI: (api: FrontAPI) => JSX.Element;
+};
+
+type GameRegistry = Map<GameId, GameMeta>;
+const registry: GameRegistry = new Map();
+
+export const gameAPI = {
+  registerGame(meta: GameMeta) {
+    registry.set(meta.id, meta);
+  },
+  listGames() {
+    return Array.from(registry.values());
+  },
+  getGame(id: GameId) {
+    return registry.get(id);
+  },
+};

--- a/tests/gameAPI.test.ts
+++ b/tests/gameAPI.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { registerGame, getGame, type GameRegistration } from 'src/gameAPI';
+import {
+  registerGame,
+  getGame,
+  gameAPI,
+  type GameMeta,
+  type GameRegistration,
+} from 'src/gameAPI';
 
 describe('game registry', () => {
   it('registers and retrieves a game', () => {
@@ -37,5 +43,18 @@ describe('game registry', () => {
 
   it('getGame returns undefined for unknown slug', () => {
     expect(getGame('missing-slug')).toBeUndefined();
+  });
+
+  it('front-end registry stores and lists games', () => {
+    const meta: GameMeta = {
+      id: 'frontend-game',
+      name: 'Front Test',
+      minPlayers: 1,
+      maxPlayers: 2,
+      createUI: () => null as any,
+    };
+    gameAPI.registerGame(meta);
+    expect(gameAPI.getGame('frontend-game')).toBe(meta);
+    expect(gameAPI.listGames()).toContain(meta);
   });
 });


### PR DESCRIPTION
## Summary
- extend game API with minimal front-end registry and contract
- cover registry with tests for registering and listing games

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689d8b3f9dc0832f9b2f5c3a3b24093a