### PR TITLE
feat: add theme provider with mode selection

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,55 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import { ToastProvider, useToast } from './Toaster';
-
-type Theme = 'light' | 'dark';
-
-function applyTheme(theme: Theme) {
-  document.body.classList.remove('light', 'dark');
-  document.body.classList.add(theme);
-}
+import React from 'react';
+import { ToastProvider } from './Toaster';
 
 function AppContent() {
-  const [theme, setTheme] = useState<Theme>('dark');
-  const toast = useToast();
-
-  useEffect(() => {
-    const stored = localStorage.getItem('theme') as Theme | null;
-    if (stored === 'light' || stored === 'dark') {
-      setTheme(stored);
-      applyTheme(stored);
-    } else {
-      const prefersDark = window.matchMedia
-        ? window.matchMedia('(prefers-color-scheme: dark)').matches
-        : false;
-      const initial: Theme = prefersDark ? 'dark' : 'light';
-      setTheme(initial);
-      applyTheme(initial);
-    }
-  }, []);
-
-  const toggleTheme = () => {
-    const next: Theme = theme === 'dark' ? 'light' : 'dark';
-    setTheme(next);
-    applyTheme(next);
-    localStorage.setItem('theme', next);
-    toast(`Switched to ${next} mode`, 'success');
-  };
-
   return (
     <div>
       <header>
-        <button
-          className="theme-toggle"
-          onClick={toggleTheme}
-          aria-label="Toggle color theme"
-          aria-pressed={theme === 'dark'}
-        >
-          {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
-        </button>
+        <h1>Deck Arcade</h1>
       </header>
       <main role="main">
-        <h1>Deck Arcade</h1>
-        <p>The current theme is {theme} mode.</p>
         <div className="table" role="img" aria-label="Table preview" />
       </main>
     </div>

--- a/src/app/ThemeProvider.tsx
+++ b/src/app/ThemeProvider.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+type Mode = 'auto' | 'light' | 'dark';
+
+interface Props {
+  initialMode?: Mode;
+  children?: React.ReactNode;
+}
+
+export const ThemeProvider = ({ initialMode = 'auto', children }: Props) => {
+  const [mode, setMode] = useState<Mode>(
+    () => (localStorage.getItem('da_theme') as Mode) || initialMode,
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const systemDark = window.matchMedia?.(
+      '(prefers-color-scheme: dark)',
+    ).matches;
+    const resolved = mode === 'auto' ? (systemDark ? 'dark' : 'light') : mode;
+    root.setAttribute('data-theme', resolved);
+    localStorage.setItem('da_theme', mode);
+  }, [mode]);
+
+  return (
+    <div>
+      <div style={{ position: 'fixed', right: 12, bottom: 12, zIndex: 50 }}>
+        <select
+          aria-label="Theme mode"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as Mode)}
+        >
+          <option value="auto">Auto</option>
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+        </select>
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './app/App';
+import { ThemeProvider } from './app/ThemeProvider';
 import './theme.css';
 
 // The entry point for the Deck Arcade application. It mounts the
@@ -8,6 +9,8 @@ import './theme.css';
 // during development to surface potential issues early.
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,5 +1,31 @@
 :root {
   color-scheme: light dark;
+  --accent-color: #b00020;
+  --background-color: #ffffff;
+  --text-color: #111111;
+  --table-felt-color: #3f9e3f;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #121212;
+    --text-color: #f0f0f0;
+    --table-felt-color: #0a5f0a;
+  }
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --background-color: #ffffff;
+  --text-color: #111111;
+  --table-felt-color: #3f9e3f;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --background-color: #121212;
+  --text-color: #f0f0f0;
+  --table-felt-color: #0a5f0a;
 }
 
 body {
@@ -8,41 +34,6 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   transition: background-color 0.3s ease, color 0.3s ease;
-  --accent-color: #b00020;
-  --background-color: #ffffff;
-  --text-color: #111111;
-  --table-felt-color: #3f9e3f;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    --background-color: #121212;
-    --text-color: #f0f0f0;
-    --table-felt-color: #0a5f0a;
-  }
-}
-
-body.light {
-  color-scheme: light;
-  --background-color: #ffffff;
-  --text-color: #111111;
-  --table-felt-color: #3f9e3f;
-}
-
-body.dark {
-  color-scheme: dark;
-  --background-color: #121212;
-  --text-color: #f0f0f0;
-  --table-felt-color: #0a5f0a;
-}
-
-button.theme-toggle {
-  background-color: var(--accent-color);
-  color: #fff;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
 }
 
 .table {
@@ -107,3 +98,4 @@ select:focus-visible {
     animation: none !important;
   }
 }
+


### PR DESCRIPTION
## Summary
- add ThemeProvider component with auto/light/dark mode selection
- wrap app with ThemeProvider and simplify App component
- drive theme styles via data-theme attribute

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d8b537c34832f84eb24ec38e4fb6e