### PR TITLE
feat(blackjack): expose hand scoring

### DIFF
--- a/src/games/blackjack/rules.ts
+++ b/src/games/blackjack/rules.ts
@@ -1,3 +1,5 @@
+// Real blackjack core with clean UI/engine binding.
+// Dealer H17/S17 is configurable; Aces 1/11; 3:2 payout default (configurable).
 export type Rank =
   | 'A'
   | '2'
@@ -109,6 +111,16 @@ function handValue(cards: Card[]): { total: number; soft: boolean } {
 
 function isBlackjack(cards: Card[]): boolean {
   return cards.length === 2 && handValue(cards).total === 21;
+}
+
+export function scoreHand(cards: Card[]) {
+  const { total, soft } = handValue(cards);
+  return {
+    total,
+    soft,
+    blackjack: isBlackjack(cards),
+    bust: total > 21,
+  };
 }
 
 function dealerShouldHit(dealer: Card[], config: BlackjackConfig): boolean {

--- a/states.txt
+++ b/states.txt
@@ -5,15 +5,15 @@ This file catalogs all known state identifiers across the codebase. Before addin
 ## Used States
 
 src/games/blackjack/rules.ts
-- stage: 'player' (line 65)
-- stage: 'dealer' (line 65)
-- stage: 'finished' (line 65)
-- events: 'reshuffle' (line 146)
-- Outcome.result: 'win' (line 54)
-- Outcome.result: 'lose' (line 54)
-- Outcome.result: 'push' (line 54)
-- Outcome.result: 'blackjack' (line 54)
-- Outcome.result: 'surrender' (line 54)
+- stage: 'player' (line 48)
+- stage: 'dealer' (line 48)
+- stage: 'finished' (line 48)
+- events: 'reshuffle' (line 138)
+- Outcome.result: 'win' (line 29)
+- Outcome.result: 'lose' (line 29)
+- Outcome.result: 'push' (line 29)
+- Outcome.result: 'blackjack' (line 29)
+- Outcome.result: 'surrender' (line 29)
 
 src/store/moneyPool.ts
 - SettlementOutcome.result: 'win' (line 18)

--- a/tests/blackjack.test.ts
+++ b/tests/blackjack.test.ts
@@ -4,6 +4,7 @@ import {
   createInitialState,
   applyAction,
   getNextActions,
+  scoreHand,
   payouts,
   type GameState,
   type Card,
@@ -199,5 +200,18 @@ describe('auto resolve', () => {
     state.shoeSize = 1;
     applyAction(state, 'hit');
     expect(state.stage).toBe('finished');
+  });
+});
+
+describe('scoreHand', () => {
+  it('handles aces as 1 or 11 and detects blackjack', () => {
+    const soft = scoreHand([card('A'), card('6')]);
+    expect(soft.total).toBe(17);
+    expect(soft.soft).toBe(true);
+    const hard = scoreHand([card('A'), card('9'), card('7')]);
+    expect(hard.total).toBe(17);
+    expect(hard.soft).toBe(false);
+    const bj = scoreHand([card('A'), card('K')]);
+    expect(bj.blackjack).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- document blackjack engine capabilities
- export `scoreHand` helper for UI consumers
- test ace handling and blackjack detection

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8bd36848832faf092e94a233ed23