### PR TITLE
Add lobby session store with local signaling

### DIFF
--- a/src/app/HostPanel.tsx
+++ b/src/app/HostPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import useGameSchema from './useGameSchema';
-import { sessionStore } from '../store/session';
+import { sessionStore } from '../store/tableSession';
 import { useToast } from './Toaster';
 
 interface Props {

--- a/src/comms/TextChat.tsx
+++ b/src/comms/TextChat.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Filter } from 'bad-words';
 import { Msg } from '../net/protocol';
-import { sessionStore } from '../store/session';
+import { sessionStore } from '../store/tableSession';
 import { setupPeerConnection } from '../net/webrtc';
 import { initVoicePTT, disposeVoicePTT, setMuted } from './VoicePTT';
 

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,0 +1,39 @@
+export type SetState<T> = (
+  partial: Partial<T> | ((state: T) => Partial<T>),
+) => void;
+export type GetState<T> = () => T;
+
+export interface Store<T> {
+  getState: GetState<T>;
+  setState: SetState<T>;
+  subscribe: (listener: (state: T) => void) => () => void;
+}
+
+export function createStore<T>(
+  initializer: (set: SetState<T>, get: GetState<T>) => T,
+): Store<T> {
+  let state: T;
+  const listeners = new Set<(state: T) => void>();
+
+  const setState: SetState<T> = (partial) => {
+    const partialState =
+      typeof partial === 'function'
+        ? (partial as (s: T) => Partial<T>)(state)
+        : partial;
+    state = { ...state, ...partialState };
+    listeners.forEach((l) => l(state));
+  };
+
+  const getState: GetState<T> = () => state;
+
+  state = initializer(setState, getState);
+
+  return {
+    getState,
+    setState,
+    subscribe(listener: (state: T) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -1,154 +1,267 @@
-import { encodeMsg, Msg } from '../net/protocol';
+// Session + Lobby (PIN) + Chat + Host controls, no external deps.
+import { createStore } from './createStore';
 
-export interface SessionState {
-  roomId?: string;
-  playerId?: string;
-  seat?: number;
-  muted?: boolean;
-  muteReason?: string;
-  isPrivate?: boolean;
-  /** Whether the local player has marked themselves ready */
-  ready?: boolean;
-  /** True if the player joined as a spectator */
-  isSpectator?: boolean;
-  /** Set when the host has paused the table */
-  paused?: boolean;
+export type Peer = {
+  id: string;
+  name: string;
+  emoji?: string;
+  isHost?: boolean;
+  connected: boolean;
+  balanceCents: number;
+};
+
+export type ChatMsg = { id: string; userId: string; text: string; ts: number };
+
+export type GameRules = {
+  blackjack?: {
+    numDecks: number;
+    dealerHitsSoft17: boolean; // H17 vs S17 config (common casino variants). :contentReference[oaicite:1]{index=1}
+    blackjackPayout: number; // 1.5 for 3:2, 1.2 for 6:5, etc.
+    allowDouble: boolean;
+    allowSplit: boolean;
+    allowDoubleAfterSplit: boolean;
+    dealerPeek: boolean;
+    allowSurrender: boolean;
+  };
+  // other games here...
+};
+
+export type LobbyState = {
+  pin: string | null;
+  hostId: string | null;
+  gameId: string | null;
+  rules: GameRules;
+  peers: Record<string, Peer>;
+  status: 'idle' | 'open' | 'playing' | 'ended';
+  chat: ChatMsg[];
+};
+
+export type SessionState = {
+  self: Peer | null;
+  lobby: LobbyState;
+};
+
+type SignalingEvent =
+  | { type: 'peer-joined'; peer: Peer }
+  | { type: 'peer-left'; peerId: string }
+  | { type: 'chat'; msg: ChatMsg }
+  | { type: 'lobby-update'; patch: Partial<LobbyState> }
+  | { type: 'start-game' }
+  | { type: 'end-game' };
+
+export interface Signaling {
+  createLobby(pin: string, host: Peer): Promise<void>;
+  joinLobby(pin: string, peer: Peer): Promise<void>;
+  leaveLobby(pin: string, peerId: string): Promise<void>;
+  broadcast(pin: string, ev: SignalingEvent): Promise<void>;
+  onMessage(pin: string, handler: (ev: SignalingEvent) => void): void;
 }
 
-function getLocal(key: string): string | null {
-  return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+// Simple in-tab dev bus so you can click around without a server.
+// Swap for your WebSocket/WebRTC signaling. Uses RTCDataChannel in production. :contentReference[oaicite:2]{index=2}
+class LocalBus implements Signaling {
+  private static rooms = new Map<string, EventTarget>();
+  private room(pin: string) {
+    if (!LocalBus.rooms.has(pin)) LocalBus.rooms.set(pin, new EventTarget());
+    return LocalBus.rooms.get(pin)!;
+  }
+  async createLobby(pin: string, _host: Peer) {
+    this.room(pin);
+  }
+  async joinLobby(pin: string, peer: Peer) {
+    this.room(pin).dispatchEvent(
+      new CustomEvent('msg', {
+        detail: { type: 'peer-joined', peer } as SignalingEvent,
+      }),
+    );
+  }
+  async leaveLobby(pin: string, peerId: string) {
+    this.room(pin).dispatchEvent(
+      new CustomEvent('msg', {
+        detail: { type: 'peer-left', peerId } as SignalingEvent,
+      }),
+    );
+  }
+  async broadcast(pin: string, ev: SignalingEvent) {
+    this.room(pin).dispatchEvent(new CustomEvent('msg', { detail: ev }));
+  }
+  onMessage(pin: string, handler: (ev: SignalingEvent) => void) {
+    this.room(pin).addEventListener('msg', (e: Event) =>
+      handler((e as CustomEvent).detail),
+    );
+  }
+}
+export const DevSignaling = new LocalBus();
+
+function genId(prefix = 'u'): string {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+}
+export function generatePIN(len = 6): string {
+  const chars = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'; // no ambigious chars
+  let out = '';
+  for (let i = 0; i < len; i++)
+    out += chars[Math.floor(Math.random() * chars.length)];
+  return out;
 }
 
-export const sessionStore = {
-  state: {} as SessionState,
-  tables: [] as { id: string; config: Record<string, unknown> }[],
-  profile: JSON.parse(getLocal('profile') || '{}') as {
-    name?: string;
-    avatar?: string;
-  },
-  resumeToken: getLocal('resumeToken') || undefined,
+export const session = createStore<SessionState>(
+  (set, get) =>
+    ({
+      self: null,
+      lobby: {
+        pin: null,
+        hostId: null,
+        gameId: null,
+        rules: {
+          blackjack: {
+            numDecks: 6,
+            dealerHitsSoft17: true,
+            blackjackPayout: 1.5,
+            allowDouble: true,
+            allowSplit: true,
+            allowDoubleAfterSplit: true,
+            dealerPeek: true,
+            allowSurrender: false,
+          },
+        },
+        peers: {},
+        status: 'idle',
+        chat: [],
+      },
+      // Actions (attached below)
+    }) as any,
+);
 
-  setProfile(profile: { name: string; avatar?: string }) {
-    this.profile = profile;
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('profile', JSON.stringify(profile));
-    }
+// Actions
+export const sessionActions = {
+  attachSignaling(sig: Signaling) {
+    (session as any)._sig = sig;
   },
-
-  handleResumeToken(token: string) {
-    this.resumeToken = token;
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('resumeToken', token);
-    }
-  },
-
-  resume(): string | null {
-    if (!this.resumeToken) return null;
-    return encodeMsg({ type: 'HELLO', resumeToken: this.resumeToken });
-  },
-
-  join(
-    roomId: string,
-    playerId: string,
-    isPrivate = false,
-    isSpectator = false,
-  ): string {
-    this.state.roomId = roomId;
-    this.state.playerId = playerId;
-    this.state.isPrivate = isPrivate;
-    this.state.muted = false;
-    this.state.muteReason = undefined;
-    this.state.isSpectator = isSpectator;
-    const msg: Msg = {
-      type: 'JOIN',
-      roomId,
-      playerId,
-      profile: this.profile.name
-        ? (this.profile as { name: string; avatar?: string })
-        : undefined,
+  async createLobby(hostName: string, emoji?: string) {
+    const pin = generatePIN();
+    const host: Peer = {
+      id: genId('host'),
+      name: hostName,
+      emoji,
+      isHost: true,
+      connected: true,
+      balanceCents: 0,
     };
-    return encodeMsg(msg);
+    const sig: Signaling = (session as any)._sig || DevSignaling;
+    await sig.createLobby(pin, host);
+    sig.onMessage(pin, (ev) => handleSignal(ev));
+    session.setState({
+      self: host,
+      lobby: {
+        ...session.getState().lobby,
+        pin,
+        hostId: host.id,
+        peers: { [host.id]: host },
+        status: 'open',
+      },
+    });
   },
-
-  leave(): string | null {
-    if (!this.state.roomId || !this.state.playerId) return null;
-    const msg: Msg = {
-      type: 'LEAVE',
-      roomId: this.state.roomId,
-      playerId: this.state.playerId,
+  async joinLobby(pin: string, name: string, emoji?: string) {
+    const self: Peer = {
+      id: genId('p'),
+      name,
+      emoji,
+      connected: true,
+      isHost: false,
+      balanceCents: 0,
     };
-    this.state = {} as SessionState;
-    return encodeMsg(msg);
+    const sig: Signaling = (session as any)._sig || DevSignaling;
+    sig.onMessage(pin, (ev) => handleSignal(ev));
+    await sig.joinLobby(pin, self);
+    session.setState({
+      self,
+      lobby: { ...session.getState().lobby, pin, status: 'open' },
+    });
   },
-
-  createTable(config: Record<string, unknown>) {
-    const snapshot = JSON.parse(JSON.stringify(config));
-    const table = {
-      id: `table-${this.tables.length + 1}`,
-      config: snapshot,
+  async leaveLobby() {
+    const st = session.getState();
+    const pin = st.lobby.pin;
+    if (!pin || !st.self) return;
+    const sig: Signaling = (session as any)._sig || DevSignaling;
+    await sig.leaveLobby(pin, st.self.id);
+    session.setState({
+      self: null,
+      lobby: {
+        ...st.lobby,
+        status: 'idle',
+        pin: null,
+        peers: {},
+        chat: [],
+        hostId: null,
+        gameId: null,
+      },
+    });
+  },
+  setGame(gameId: string | null) {
+    const l = session.getState().lobby;
+    session.setState({ lobby: { ...l, gameId } });
+    broadcast({ type: 'lobby-update', patch: { gameId } });
+  },
+  setBlackjackRule<K extends keyof NonNullable<GameRules['blackjack']>>(
+    key: K,
+    value: NonNullable<GameRules['blackjack']>[K],
+  ) {
+    const l = session.getState().lobby;
+    const bj = { ...(l.rules.blackjack || {}) } as GameRules['blackjack'];
+    (bj as any)[key] = value;
+    const rules = { ...l.rules, blackjack: bj };
+    session.setState({ lobby: { ...l, rules } });
+    broadcast({ type: 'lobby-update', patch: { rules } });
+  },
+  sendChat(text: string) {
+    const st = session.getState();
+    if (!st.self || !st.lobby.pin) return;
+    const msg: ChatMsg = {
+      id: genId('m'),
+      userId: st.self.id,
+      text,
+      ts: Date.now(),
     };
-    this.tables.push(table);
-    return table;
+    broadcast({ type: 'chat', msg });
+    const chat = [...st.lobby.chat, msg];
+    session.setState({ lobby: { ...st.lobby, chat } });
   },
-
-  /**
-   * Toggle the local ready state and produce a READY message for broadcast.
-   * The caller is responsible for sending the returned payload over the wire.
-   */
-  ready(ready = true): string | null {
-    if (!this.state.playerId) return null;
-    this.state.ready = ready;
-    const msg: Msg = { type: 'READY', playerId: this.state.playerId, ready };
-    return encodeMsg(msg);
+  startGame() {
+    const l = session.getState().lobby;
+    session.setState({ lobby: { ...l, status: 'playing' } });
+    broadcast({ type: 'start-game' });
   },
-
-  /** mark the local client as a spectator */
-  setSpectator(isSpectator: boolean) {
-    this.state.isSpectator = isSpectator;
-  },
-
-  /**
-   * Host controls -----------------------------------------------------------
-   */
-
-  pause(): string | null {
-    if (!this.state.roomId) return null;
-    this.state.paused = true;
-    return encodeMsg({ type: 'PAUSE', roomId: this.state.roomId });
-  },
-
-  resumeGame(): string | null {
-    if (!this.state.roomId) return null;
-    this.state.paused = false;
-    return encodeMsg({ type: 'RESUME', roomId: this.state.roomId });
-  },
-
-  endGame(): string | null {
-    if (!this.state.roomId) return null;
-    return encodeMsg({ type: 'END_GAME', roomId: this.state.roomId });
-  },
-
-  /**
-   * Basic per-turn timer. Starts a timeout and invokes the callback when the
-   * deadline is reached. The deadline timestamp is stored for UI countdowns.
-   */
-  turnTimer: undefined as ReturnType<typeof setTimeout> | undefined,
-  turnDeadline: undefined as number | undefined,
-  startTurnTimer(seconds: number, onTimeout: () => void) {
-    this.clearTurnTimer();
-    this.turnDeadline = Date.now() + seconds * 1000;
-    this.turnTimer = setTimeout(() => {
-      this.turnTimer = undefined;
-      this.turnDeadline = undefined;
-      onTimeout();
-    }, seconds * 1000);
-  },
-
-  clearTurnTimer() {
-    if (this.turnTimer) {
-      clearTimeout(this.turnTimer);
-      this.turnTimer = undefined;
-    }
-    this.turnDeadline = undefined;
+  endGame() {
+    const l = session.getState().lobby;
+    session.setState({ lobby: { ...l, status: 'ended' } });
+    broadcast({ type: 'end-game' });
   },
 };
+
+function broadcast(ev: SignalingEvent) {
+  const st = session.getState();
+  const sig: Signaling = (session as any)._sig || DevSignaling;
+  if (!st.lobby.pin) return;
+  void sig.broadcast(st.lobby.pin, ev);
+}
+
+function handleSignal(ev: SignalingEvent) {
+  const st = session.getState();
+  const l = st.lobby;
+  if (ev.type === 'peer-joined' && ev.peer) {
+    session.setState({
+      lobby: { ...l, peers: { ...l.peers, [ev.peer.id]: ev.peer } },
+    });
+  } else if (ev.type === 'peer-left') {
+    const { [ev.peerId]: _, ...rest } = l.peers;
+    session.setState({ lobby: { ...l, peers: rest } });
+  } else if (ev.type === 'chat') {
+    session.setState({ lobby: { ...l, chat: [...l.chat, ev.msg] } });
+  } else if (ev.type === 'lobby-update') {
+    session.setState({ lobby: { ...l, ...ev.patch } });
+  } else if (ev.type === 'start-game') {
+    session.setState({ lobby: { ...l, status: 'playing' } });
+  } else if (ev.type === 'end-game') {
+    session.setState({ lobby: { ...l, status: 'ended' } });
+  }
+}

--- a/src/store/tableSession.ts
+++ b/src/store/tableSession.ts
@@ -1,0 +1,154 @@
+import { encodeMsg, Msg } from '../net/protocol';
+
+export interface SessionState {
+  roomId?: string;
+  playerId?: string;
+  seat?: number;
+  muted?: boolean;
+  muteReason?: string;
+  isPrivate?: boolean;
+  /** Whether the local player has marked themselves ready */
+  ready?: boolean;
+  /** True if the player joined as a spectator */
+  isSpectator?: boolean;
+  /** Set when the host has paused the table */
+  paused?: boolean;
+}
+
+function getLocal(key: string): string | null {
+  return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+}
+
+export const sessionStore = {
+  state: {} as SessionState,
+  tables: [] as { id: string; config: Record<string, unknown> }[],
+  profile: JSON.parse(getLocal('profile') || '{}') as {
+    name?: string;
+    avatar?: string;
+  },
+  resumeToken: getLocal('resumeToken') || undefined,
+
+  setProfile(profile: { name: string; avatar?: string }) {
+    this.profile = profile;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('profile', JSON.stringify(profile));
+    }
+  },
+
+  handleResumeToken(token: string) {
+    this.resumeToken = token;
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('resumeToken', token);
+    }
+  },
+
+  resume(): string | null {
+    if (!this.resumeToken) return null;
+    return encodeMsg({ type: 'HELLO', resumeToken: this.resumeToken });
+  },
+
+  join(
+    roomId: string,
+    playerId: string,
+    isPrivate = false,
+    isSpectator = false,
+  ): string {
+    this.state.roomId = roomId;
+    this.state.playerId = playerId;
+    this.state.isPrivate = isPrivate;
+    this.state.muted = false;
+    this.state.muteReason = undefined;
+    this.state.isSpectator = isSpectator;
+    const msg: Msg = {
+      type: 'JOIN',
+      roomId,
+      playerId,
+      profile: this.profile.name
+        ? (this.profile as { name: string; avatar?: string })
+        : undefined,
+    };
+    return encodeMsg(msg);
+  },
+
+  leave(): string | null {
+    if (!this.state.roomId || !this.state.playerId) return null;
+    const msg: Msg = {
+      type: 'LEAVE',
+      roomId: this.state.roomId,
+      playerId: this.state.playerId,
+    };
+    this.state = {} as SessionState;
+    return encodeMsg(msg);
+  },
+
+  createTable(config: Record<string, unknown>) {
+    const snapshot = JSON.parse(JSON.stringify(config));
+    const table = {
+      id: `table-${this.tables.length + 1}`,
+      config: snapshot,
+    };
+    this.tables.push(table);
+    return table;
+  },
+
+  /**
+   * Toggle the local ready state and produce a READY message for broadcast.
+   * The caller is responsible for sending the returned payload over the wire.
+   */
+  ready(ready = true): string | null {
+    if (!this.state.playerId) return null;
+    this.state.ready = ready;
+    const msg: Msg = { type: 'READY', playerId: this.state.playerId, ready };
+    return encodeMsg(msg);
+  },
+
+  /** mark the local client as a spectator */
+  setSpectator(isSpectator: boolean) {
+    this.state.isSpectator = isSpectator;
+  },
+
+  /**
+   * Host controls -----------------------------------------------------------
+   */
+
+  pause(): string | null {
+    if (!this.state.roomId) return null;
+    this.state.paused = true;
+    return encodeMsg({ type: 'PAUSE', roomId: this.state.roomId });
+  },
+
+  resumeGame(): string | null {
+    if (!this.state.roomId) return null;
+    this.state.paused = false;
+    return encodeMsg({ type: 'RESUME', roomId: this.state.roomId });
+  },
+
+  endGame(): string | null {
+    if (!this.state.roomId) return null;
+    return encodeMsg({ type: 'END_GAME', roomId: this.state.roomId });
+  },
+
+  /**
+   * Basic per-turn timer. Starts a timeout and invokes the callback when the
+   * deadline is reached. The deadline timestamp is stored for UI countdowns.
+   */
+  turnTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+  turnDeadline: undefined as number | undefined,
+  startTurnTimer(seconds: number, onTimeout: () => void) {
+    this.clearTurnTimer();
+    this.turnDeadline = Date.now() + seconds * 1000;
+    this.turnTimer = setTimeout(() => {
+      this.turnTimer = undefined;
+      this.turnDeadline = undefined;
+      onTimeout();
+    }, seconds * 1000);
+  },
+
+  clearTurnTimer() {
+    if (this.turnTimer) {
+      clearTimeout(this.turnTimer);
+      this.turnTimer = undefined;
+    }
+    this.turnDeadline = undefined;
+  },
+};

--- a/tests/HostPanel.test.tsx
+++ b/tests/HostPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import HostPanel from 'src/app/HostPanel';
-import { sessionStore } from 'src/store/session';
+import { sessionStore } from 'src/store/tableSession';
 
 const schema = {
   properties: {


### PR DESCRIPTION
## Summary
- introduce a lobby-oriented session store with PIN generation and in-tab signaling bus
- provide a minimal generic store helper
- move previous sessionStore to `tableSession` and update host panel, chat, and tests

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d8bb88c6c832f93918bff5eaa3dcb