### PR TITLE
feat: add money pool store

### DIFF
--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,0 +1,11 @@
+export function createStore<T>(init: () => T) {
+  let state = init();
+  return {
+    getState() {
+      return state;
+    },
+    setState(partial: Partial<T>) {
+      state = { ...state, ...partial };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- implement a ledger-based money pool with deposits, withdrawals, pot transfers and payouts
- provide simple createStore helper for state management
- update blackjack betting to use new money pool actions and add comprehensive tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8bc66890832f9ac4c6e67d56094a