### PR TITLE
Add lobby join UI and session helpers

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ToastProvider, useToast } from './Toaster';
+import { LobbyJoin } from './LobbyJoin';
 
 type Theme = 'light' | 'dark';
 
@@ -47,11 +48,7 @@ function AppContent() {
           {theme === 'dark' ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>
       </header>
-      <main role="main">
-        <h1>Deck Arcade</h1>
-        <p>The current theme is {theme} mode.</p>
-        <div className="table" role="img" aria-label="Table preview" />
-      </main>
+      <LobbyJoin />
     </div>
   );
 }

--- a/src/app/LobbyJoin.tsx
+++ b/src/app/LobbyJoin.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { session, sessionActions } from '../store/session';
+
+export const LobbyJoin: React.FC = () => {
+  const [pin, setPin] = useState('');
+  const [name, setName] = useState('');
+  const [emoji, setEmoji] = useState('🂡');
+  const s = session.getState();
+  return (
+    <main className="container" style={{ display: 'grid', gap: '1rem' }}>
+      <div className="card" style={{ padding: '1rem' }}>
+        <h2>Join a Lobby</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            sessionActions.joinLobby(
+              pin.trim().toUpperCase(),
+              name.trim(),
+              emoji,
+            );
+          }}
+        >
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: '.75rem',
+              maxWidth: 560,
+            }}
+          >
+            <label>
+              PIN
+              <br />
+              <input
+                value={pin}
+                onChange={(e) => setPin(e.target.value)}
+                placeholder="e.g., J9K3Q2"
+              />
+            </label>
+            <label>
+              Name
+              <br />
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g., Jason"
+              />
+            </label>
+          </div>
+          <div style={{ marginTop: '.75rem' }}>
+            <button
+              type="submit"
+              style={{
+                minHeight: 44,
+                borderRadius: 12,
+                padding: '0 1rem',
+                background: 'var(--accentPrimary)',
+                border: 0,
+              }}
+            >
+              Join
+            </button>
+          </div>
+        </form>
+      </div>
+      {s.lobby.pin && (
+        <div className="card" style={{ padding: '1rem' }}>
+          <strong>Lobby: {s.lobby.pin}</strong>
+          <div style={{ display: 'grid', gap: '.25rem', marginTop: '.5rem' }}>
+            {Object.values(s.lobby.peers).map((p) => (
+              <div key={p.id}>
+                {p.emoji || '🙂'} {p.name}
+                {p.isHost ? ' (Host)' : ''}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </main>
+  );
+};

--- a/src/store/session.ts
+++ b/src/store/session.ts
@@ -15,12 +15,25 @@ export interface SessionState {
   paused?: boolean;
 }
 
+export interface LobbyPeer {
+  id: string;
+  name: string;
+  emoji?: string;
+  isHost?: boolean;
+}
+
+export interface LobbyState {
+  pin?: string;
+  peers: Record<string, LobbyPeer>;
+}
+
 function getLocal(key: string): string | null {
   return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
 }
 
 export const sessionStore = {
   state: {} as SessionState,
+  lobby: { peers: {} } as LobbyState,
   tables: [] as { id: string; config: Record<string, unknown> }[],
   profile: JSON.parse(getLocal('profile') || '{}') as {
     name?: string;
@@ -150,5 +163,17 @@ export const sessionStore = {
       this.turnTimer = undefined;
     }
     this.turnDeadline = undefined;
+  },
+};
+
+export const session = {
+  getState: () => sessionStore,
+};
+
+export const sessionActions = {
+  joinLobby(pin: string, name: string, emoji: string) {
+    sessionStore.lobby.pin = pin;
+    const id = Math.random().toString(36).slice(2);
+    sessionStore.lobby.peers[id] = { id, name, emoji };
   },
 };


### PR DESCRIPTION
## Summary
- add `LobbyJoin` component for joining lobbies and displaying connected peers
- expose lobby state and `joinLobby` action from session store
- render `LobbyJoin` in main app

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8c17f468832faa19a6b1eb7a179a